### PR TITLE
Add daily LDAP sync job

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,8 +25,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        //  Syncronize Lara Persons with the latest status on the LDAP server
+        $schedule->command('ldapsync')->->dailyAt('04:00');
     }
 
     /**


### PR DESCRIPTION
Will syncronize Lara Persons with LDAP daily at 04:00.
For this to work a cron job should be installed on the server. 
Example:
To support task scheduling, a cronjob should be added to /etc/crontab:
* * * * * root php /path/to/your/Lara/folder/artisan schedule:run >> /dev/null 2>&1