### PR TITLE
Feature/generic section colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Code published under [GNU GPL v.3](https://github.com/ILSCeV/Lara/blob/master/LI
 Lara VedSt is based on: 
 - [Laravel 5.4](http://laravel.com)
 - [Bootswatch](http://bootswatch.com)
+- [Google Material Color implementation](https://github.com/danlevan/google-material-color)
 - [JQuery](http://jquery.com)
 - [Font Awesome](http://fortawesome.github.io/Font-Awesome) 
 - [Isotope](http://isotope.metafizzy.co/)

--- a/app/ClubEvent.php
+++ b/app/ClubEvent.php
@@ -42,16 +42,16 @@ class ClubEvent extends Model
      * @var $fillable array
      */
     protected $fillable = [
-        'evnt_type',            // 0 -> default -> "normales Programm"
-                                // 1 -> info only
-                                // 2 -> highlight / special
-                                // 3 -> live band / DJ / reading
-                                // 4 -> internal event
-                                // 5 -> private party -> "Nutzung"
-                                // 6 -> cleaning -> "Fluten"
-                                // 7 -> flyer / poster
-                                // 8 -> tickets -> "Vorverkauf"
-                                // 9 -> internal task -> everything else
+        'evnt_type',            // 0 -> default -> "normales Programm"          Shade:     700
+                                // 1 -> info only                               Shade:    500, always purple
+                                // 2 -> highlight / special                     Shade:       900
+                                // 3 -> live band / DJ / reading                Shade:       900
+                                // 4 -> internal event                          Shade:    500
+                                // 5 -> private party -> "Nutzung"              Shade:    500
+                                // 6 -> cleaning -> "Fluten"                    Shade:    500
+                                // 7 -> flyer / poster                          Shade:  300
+                                // 8 -> tickets -> "Vorverkauf"                 Shade:  300
+                                // 9 -> internal task -> everything else        Shade:    500
         'evnt_title',
         'evnt_subtitle',
         'plc_id',

--- a/config/color.php
+++ b/config/color.php
@@ -1,0 +1,70 @@
+<?php
+
+return [
+
+    /*
+     |--------------------------------------------------------------------------
+     | Google Material Color Implementation
+     |--------------------------------------------------------------------------
+     |
+     | References: https://material.io/guidelines/style/color.html#color-color-palette
+     |             https://github.com/danlevan/google-material-color
+     | 
+     */
+
+	"colors" => [
+		"Red", 
+		"Pink", 
+		"Purple", 
+		"Deep Purple", 
+		"Indigo", 
+		"Blue", 
+		"Light Blue", 
+		"Cyan", 
+		"Teal", 
+		"Green", 
+		"Light Green", 
+		"Lime", 
+		"Yellow", 
+		"Amber", 
+		"Orange", 
+		"Deep Orange", 
+		"Brown",          // Doesn't have shades: A100, A200, A400, A700
+		"Grey",           // Doesn't have shades: A100, A200, A400, A700
+		"Blue Grey"       // Doesn't have shades: A100, A200, A400, A700
+	],
+
+    // Note that not all color have all the shades
+	"shades" => [
+		"50", 
+		"100", 
+		"200", 
+		"300", 
+		"400", 
+		"500", 
+		"600", 
+		"700", 
+		"800", 
+		"900", 
+		"A100", 
+		"A200", 
+		"A400", 
+		"A700"
+	],
+
+    "text_color" => [
+        "Black",
+        "White"
+    ],
+
+    "text_shades" => [
+        "Primary", 
+        "Secondary", 
+        "Icons", 
+        "Disabled", 
+        "Hint", 
+        "Dividers"
+    ]
+
+
+];

--- a/config/color.php
+++ b/config/color.php
@@ -16,22 +16,22 @@ return [
 		"Red", 
 		"Pink", 
 		"Purple", 
-		"Deep Purple", 
+		"Deep-Purple", 
 		"Indigo", 
 		"Blue", 
-		"Light Blue", 
+		"Light-Blue", 
 		"Cyan", 
 		"Teal", 
 		"Green", 
-		"Light Green", 
+		"Light-Green", 
 		"Lime", 
 		"Yellow", 
 		"Amber", 
 		"Orange", 
-		"Deep Orange", 
+		"Deep-Orange", 
 		"Brown",          // Doesn't have shades: A100, A200, A400, A700
 		"Grey",           // Doesn't have shades: A100, A200, A400, A700
-		"Blue Grey"       // Doesn't have shades: A100, A200, A400, A700
+		"Blue-Grey"       // Doesn't have shades: A100, A200, A400, A700
 	],
 
     // Note that not all color have all the shades

--- a/config/color.php
+++ b/config/color.php
@@ -15,7 +15,7 @@ return [
 	"colors" => [
 		"Red", 
 		"Pink", 
-		"Purple", 
+		// "Purple",      // RESERVED for Info events
 		"Deep-Purple", 
 		"Indigo", 
 		"Blue", 
@@ -29,9 +29,9 @@ return [
 		"Amber", 
 		"Orange", 
 		"Deep-Orange", 
-		"Brown",          // Doesn't have shades: A100, A200, A400, A700
-		"Grey",           // Doesn't have shades: A100, A200, A400, A700
-		"Blue-Grey"       // Doesn't have shades: A100, A200, A400, A700
+		// "Brown",          // Doesn't have shades: A100, A200, A400, A700
+		// "Grey",           // Doesn't have shades: A100, A200, A400, A700      // RESERVED for Hidden events
+		// "Blue-Grey"       // Doesn't have shades: A100, A200, A400, A700      // RESERVED for Hidden surveys
 	],
 
     // Note that not all color have all the shades

--- a/config/color.php
+++ b/config/color.php
@@ -15,8 +15,8 @@ return [
 	"colors" => [
 		"Red", 
 		"Pink", 
-		// "Purple",      // RESERVED for Info events
-		"Deep-Purple", 
+		// "Purple",      // RESERVED for Info events and Surveys
+		"Deep-Purple",
 		"Indigo", 
 		"Blue", 
 		"Light-Blue", 

--- a/database/migrations/2017_12_02_230639_default_colors_for_sections.php
+++ b/database/migrations/2017_12_02_230639_default_colors_for_sections.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Lara\Section;
+
+class DefaultColorsForSections extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        /** @var sections \Illuminate\Database\Eloquent\Collection[Section] */
+        $sections = Section::all();
+        foreach ($sections as $section) {
+            if ($section->title == 'bc-Club') {
+                $section->color = 'Red';
+            }
+            if ($section->title == 'bc-Café') {
+                $section->color = 'Blue';
+            }
+            if ($section->title == 'bd-Club') {
+                $section->color = 'Green';
+            }
+            $section->update();
+        }
+    }
+    
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+        /** @var sections \Illuminate\Database\Eloquent\Collection[Section] */
+        $sections = Section::all();
+        foreach ($sections as $section) {
+            $section->color = null;
+            $section->update();
+        }
+    }
+}

--- a/database/seeds/SectionPreferencesTableSeeder.php
+++ b/database/seeds/SectionPreferencesTableSeeder.php
@@ -16,16 +16,19 @@ class SectionPreferencesTableSeeder extends Seeder
         $bd_club = Lara\Section::where('title', 'bd-Club')->first();
 
         $bc_club->fill([
+            'color' => 'Red',
             'preparationTime' => '20:00',
             'startTime' => '21:00',
             'endTime' => '01:00'
         ]);
         $bc_cafe->fill([
+            'color' => 'Blue',
             'preparationTime' => '10:45',
             'startTime' => '12:00',
             'endTime' => '17:00'
         ]);
         $bd_club->fill([
+            'color' => 'Green',
             'preparationTime' => '20:00',
             'startTime' => '21:00',
             'endTime' => '01:00'

--- a/resources/assets/css/palette.css
+++ b/resources/assets/css/palette.css
@@ -1,0 +1,9338 @@
+/**
+ * google-material-color v1.2.6
+ * https://github.com/danlevan/google-material-color
+ */
+.palette-Red.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red.text {
+  color: #F44336;
+}
+.palette-Red-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-50.bg {
+  background-color: #FFEBEE;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Red-50.text {
+  color: #FFEBEE;
+}
+.palette-Red-50-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-50-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-50-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-50-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-50-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-50-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-100.bg {
+  background-color: #FFCDD2;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Red-100.text {
+  color: #FFCDD2;
+}
+.palette-Red-100-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-100-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-100-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-100-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-100-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-100-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-200.bg {
+  background-color: #EF9A9A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Red-200.text {
+  color: #EF9A9A;
+}
+.palette-Red-200-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-200-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-200-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-200-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-200-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-200-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-300.bg {
+  background-color: #E57373;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Red-300.text {
+  color: #E57373;
+}
+.palette-Red-300-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-300-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-300-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-300-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-300-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-300-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-400.bg {
+  background-color: #EF5350;
+  color: #ffffff;
+}
+.palette-Red-400.text {
+  color: #EF5350;
+}
+.palette-Red-400-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-400-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-400-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-400-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-400-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-400-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-500.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-500.text {
+  color: #F44336;
+}
+.palette-Red-500-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-500-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-500-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-500-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-500-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-500-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-600.bg {
+  background-color: #E53935;
+  color: #ffffff;
+}
+.palette-Red-600.text {
+  color: #E53935;
+}
+.palette-Red-600-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-600-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-600-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-600-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-600-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-600-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-700.bg {
+  background-color: #D32F2F;
+  color: #ffffff;
+}
+.palette-Red-700.text {
+  color: #D32F2F;
+}
+.palette-Red-700-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-700-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-700-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-700-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-700-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-700-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-800.bg {
+  background-color: #C62828;
+  color: #ffffff;
+}
+.palette-Red-800.text {
+  color: #C62828;
+}
+.palette-Red-800-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-800-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-800-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-800-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-800-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-800-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-900.bg {
+  background-color: #B71C1C;
+  color: #ffffff;
+}
+.palette-Red-900.text {
+  color: #B71C1C;
+}
+.palette-Red-900-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-900-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-900-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-900-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-900-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-900-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-A100.bg {
+  background-color: #FF8A80;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Red-A100.text {
+  color: #FF8A80;
+}
+.palette-Red-A100-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-A100-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-A100-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A100-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A100-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A100-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-A200.bg {
+  background-color: #FF5252;
+  color: #ffffff;
+}
+.palette-Red-A200.text {
+  color: #FF5252;
+}
+.palette-Red-A200-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-A200-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-A200-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A200-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A200-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A200-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-A400.bg {
+  background-color: #FF1744;
+  color: #ffffff;
+}
+.palette-Red-A400.text {
+  color: #FF1744;
+}
+.palette-Red-A400-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-A400-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-A400-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A400-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A400-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A400-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Red-A700.bg {
+  background-color: #D50000;
+  color: #ffffff;
+}
+.palette-Red-A700.text {
+  color: #D50000;
+}
+.palette-Red-A700-Primary.bg {
+  background-color: #F44336;
+  color: #ffffff;
+}
+.palette-Red-A700-Secondary.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Red-A700-Icons.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A700-Disabled.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A700-Hint.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Red-A700-Dividers.bg {
+  background-color: #F44336;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Pink.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink.text {
+  color: #E91E63;
+}
+.palette-Pink-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-50.bg {
+  background-color: #FCE4EC;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Pink-50.text {
+  color: #FCE4EC;
+}
+.palette-Pink-50-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-50-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-50-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-50-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-50-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-50-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-100.bg {
+  background-color: #F8BBD0;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Pink-100.text {
+  color: #F8BBD0;
+}
+.palette-Pink-100-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-100-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-100-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-100-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-100-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-100-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-200.bg {
+  background-color: #F48FB1;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Pink-200.text {
+  color: #F48FB1;
+}
+.palette-Pink-200-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-200-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-200-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-200-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-200-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-200-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-300.bg {
+  background-color: #F06292;
+  color: #ffffff;
+}
+.palette-Pink-300.text {
+  color: #F06292;
+}
+.palette-Pink-300-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-300-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-300-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-300-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-300-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-300-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-400.bg {
+  background-color: #EC407A;
+  color: #ffffff;
+}
+.palette-Pink-400.text {
+  color: #EC407A;
+}
+.palette-Pink-400-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-400-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-400-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-400-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-400-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-400-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-500.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-500.text {
+  color: #E91E63;
+}
+.palette-Pink-500-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-500-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-500-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-500-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-500-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-500-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-600.bg {
+  background-color: #D81B60;
+  color: #ffffff;
+}
+.palette-Pink-600.text {
+  color: #D81B60;
+}
+.palette-Pink-600-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-600-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-600-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-600-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-600-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-600-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-700.bg {
+  background-color: #C2185B;
+  color: #ffffff;
+}
+.palette-Pink-700.text {
+  color: #C2185B;
+}
+.palette-Pink-700-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-700-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-700-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-700-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-700-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-700-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-800.bg {
+  background-color: #AD1457;
+  color: #ffffff;
+}
+.palette-Pink-800.text {
+  color: #AD1457;
+}
+.palette-Pink-800-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-800-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-800-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-800-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-800-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-800-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-900.bg {
+  background-color: #880E4F;
+  color: #ffffff;
+}
+.palette-Pink-900.text {
+  color: #880E4F;
+}
+.palette-Pink-900-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-900-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-900-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-900-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-900-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-900-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-A100.bg {
+  background-color: #FF80AB;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Pink-A100.text {
+  color: #FF80AB;
+}
+.palette-Pink-A100-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-A100-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-A100-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A100-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A100-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A100-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-A200.bg {
+  background-color: #FF4081;
+  color: #ffffff;
+}
+.palette-Pink-A200.text {
+  color: #FF4081;
+}
+.palette-Pink-A200-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-A200-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-A200-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A200-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A200-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A200-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-A400.bg {
+  background-color: #F50057;
+  color: #ffffff;
+}
+.palette-Pink-A400.text {
+  color: #F50057;
+}
+.palette-Pink-A400-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-A400-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-A400-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A400-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A400-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A400-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Pink-A700.bg {
+  background-color: #C51162;
+  color: #ffffff;
+}
+.palette-Pink-A700.text {
+  color: #C51162;
+}
+.palette-Pink-A700-Primary.bg {
+  background-color: #E91E63;
+  color: #ffffff;
+}
+.palette-Pink-A700-Secondary.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Pink-A700-Icons.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A700-Disabled.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A700-Hint.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Pink-A700-Dividers.bg {
+  background-color: #E91E63;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Purple.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple.text {
+  color: #9C27B0;
+}
+.palette-Purple-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-50.bg {
+  background-color: #F3E5F5;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Purple-50.text {
+  color: #F3E5F5;
+}
+.palette-Purple-50-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-50-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-50-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-50-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-50-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-50-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-100.bg {
+  background-color: #E1BEE7;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Purple-100.text {
+  color: #E1BEE7;
+}
+.palette-Purple-100-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-100-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-100-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-100-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-100-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-100-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-200.bg {
+  background-color: #CE93D8;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Purple-200.text {
+  color: #CE93D8;
+}
+.palette-Purple-200-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-200-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-200-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-200-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-200-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-200-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-300.bg {
+  background-color: #BA68C8;
+  color: #ffffff;
+}
+.palette-Purple-300.text {
+  color: #BA68C8;
+}
+.palette-Purple-300-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-300-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-300-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-300-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-300-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-300-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-400.bg {
+  background-color: #AB47BC;
+  color: #ffffff;
+}
+.palette-Purple-400.text {
+  color: #AB47BC;
+}
+.palette-Purple-400-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-400-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-400-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-400-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-400-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-400-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-500.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-500.text {
+  color: #9C27B0;
+}
+.palette-Purple-500-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-500-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-500-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-500-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-500-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-500-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-600.bg {
+  background-color: #8E24AA;
+  color: #ffffff;
+}
+.palette-Purple-600.text {
+  color: #8E24AA;
+}
+.palette-Purple-600-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-600-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-600-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-600-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-600-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-600-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-700.bg {
+  background-color: #7B1FA2;
+  color: #ffffff;
+}
+.palette-Purple-700.text {
+  color: #7B1FA2;
+}
+.palette-Purple-700-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-700-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-700-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-700-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-700-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-700-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-800.bg {
+  background-color: #6A1B9A;
+  color: #ffffff;
+}
+.palette-Purple-800.text {
+  color: #6A1B9A;
+}
+.palette-Purple-800-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-800-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-800-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-800-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-800-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-800-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-900.bg {
+  background-color: #4A148C;
+  color: #ffffff;
+}
+.palette-Purple-900.text {
+  color: #4A148C;
+}
+.palette-Purple-900-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-900-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-900-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-900-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-900-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-900-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-A100.bg {
+  background-color: #EA80FC;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Purple-A100.text {
+  color: #EA80FC;
+}
+.palette-Purple-A100-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-A100-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-A100-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A100-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A100-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A100-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-A200.bg {
+  background-color: #E040FB;
+  color: #ffffff;
+}
+.palette-Purple-A200.text {
+  color: #E040FB;
+}
+.palette-Purple-A200-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-A200-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-A200-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A200-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A200-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A200-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-A400.bg {
+  background-color: #D500F9;
+  color: #ffffff;
+}
+.palette-Purple-A400.text {
+  color: #D500F9;
+}
+.palette-Purple-A400-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-A400-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-A400-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A400-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A400-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A400-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Purple-A700.bg {
+  background-color: #AA00FF;
+  color: #ffffff;
+}
+.palette-Purple-A700.text {
+  color: #AA00FF;
+}
+.palette-Purple-A700-Primary.bg {
+  background-color: #9C27B0;
+  color: #ffffff;
+}
+.palette-Purple-A700-Secondary.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Purple-A700-Icons.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A700-Disabled.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A700-Hint.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Purple-A700-Dividers.bg {
+  background-color: #9C27B0;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Deep-Purple.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple.text {
+  color: #673AB7;
+}
+.palette-Deep-Purple-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-50.bg {
+  background-color: #EDE7F6;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Purple-50.text {
+  color: #EDE7F6;
+}
+.palette-Deep-Purple-50-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-50-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-50-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-50-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-50-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-50-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-100.bg {
+  background-color: #D1C4E9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Purple-100.text {
+  color: #D1C4E9;
+}
+.palette-Deep-Purple-100-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-100-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-100-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-100-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-100-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-100-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-200.bg {
+  background-color: #B39DDB;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Purple-200.text {
+  color: #B39DDB;
+}
+.palette-Deep-Purple-200-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-200-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-200-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-200-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-200-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-200-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-300.bg {
+  background-color: #9575CD;
+  color: #ffffff;
+}
+.palette-Deep-Purple-300.text {
+  color: #9575CD;
+}
+.palette-Deep-Purple-300-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-300-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-300-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-300-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-300-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-300-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-400.bg {
+  background-color: #7E57C2;
+  color: #ffffff;
+}
+.palette-Deep-Purple-400.text {
+  color: #7E57C2;
+}
+.palette-Deep-Purple-400-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-400-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-400-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-400-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-400-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-400-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-500.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-500.text {
+  color: #673AB7;
+}
+.palette-Deep-Purple-500-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-500-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-500-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-500-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-500-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-500-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-600.bg {
+  background-color: #5E35B1;
+  color: #ffffff;
+}
+.palette-Deep-Purple-600.text {
+  color: #5E35B1;
+}
+.palette-Deep-Purple-600-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-600-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-600-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-600-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-600-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-600-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-700.bg {
+  background-color: #512DA8;
+  color: #ffffff;
+}
+.palette-Deep-Purple-700.text {
+  color: #512DA8;
+}
+.palette-Deep-Purple-700-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-700-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-700-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-700-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-700-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-700-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-800.bg {
+  background-color: #4527A0;
+  color: #ffffff;
+}
+.palette-Deep-Purple-800.text {
+  color: #4527A0;
+}
+.palette-Deep-Purple-800-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-800-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-800-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-800-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-800-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-800-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-900.bg {
+  background-color: #311B92;
+  color: #ffffff;
+}
+.palette-Deep-Purple-900.text {
+  color: #311B92;
+}
+.palette-Deep-Purple-900-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-900-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-900-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-900-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-900-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-900-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-A100.bg {
+  background-color: #B388FF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Purple-A100.text {
+  color: #B388FF;
+}
+.palette-Deep-Purple-A100-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A100-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-A100-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A100-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A100-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A100-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-A200.bg {
+  background-color: #7C4DFF;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A200.text {
+  color: #7C4DFF;
+}
+.palette-Deep-Purple-A200-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A200-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-A200-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A200-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A200-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A200-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-A400.bg {
+  background-color: #651FFF;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A400.text {
+  color: #651FFF;
+}
+.palette-Deep-Purple-A400-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A400-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-A400-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A400-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A400-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A400-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Purple-A700.bg {
+  background-color: #6200EA;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A700.text {
+  color: #6200EA;
+}
+.palette-Deep-Purple-A700-Primary.bg {
+  background-color: #673AB7;
+  color: #ffffff;
+}
+.palette-Deep-Purple-A700-Secondary.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Purple-A700-Icons.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A700-Disabled.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A700-Hint.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Purple-A700-Dividers.bg {
+  background-color: #673AB7;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Indigo.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo.text {
+  color: #3F51B5;
+}
+.palette-Indigo-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-50.bg {
+  background-color: #E8EAF6;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Indigo-50.text {
+  color: #E8EAF6;
+}
+.palette-Indigo-50-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-50-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-50-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-50-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-50-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-50-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-100.bg {
+  background-color: #C5CAE9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Indigo-100.text {
+  color: #C5CAE9;
+}
+.palette-Indigo-100-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-100-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-100-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-100-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-100-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-100-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-200.bg {
+  background-color: #9FA8DA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Indigo-200.text {
+  color: #9FA8DA;
+}
+.palette-Indigo-200-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-200-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-200-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-200-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-200-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-200-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-300.bg {
+  background-color: #7986CB;
+  color: #ffffff;
+}
+.palette-Indigo-300.text {
+  color: #7986CB;
+}
+.palette-Indigo-300-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-300-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-300-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-300-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-300-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-300-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-400.bg {
+  background-color: #5C6BC0;
+  color: #ffffff;
+}
+.palette-Indigo-400.text {
+  color: #5C6BC0;
+}
+.palette-Indigo-400-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-400-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-400-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-400-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-400-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-400-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-500.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-500.text {
+  color: #3F51B5;
+}
+.palette-Indigo-500-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-500-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-500-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-500-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-500-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-500-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-600.bg {
+  background-color: #3949AB;
+  color: #ffffff;
+}
+.palette-Indigo-600.text {
+  color: #3949AB;
+}
+.palette-Indigo-600-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-600-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-600-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-600-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-600-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-600-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-700.bg {
+  background-color: #303F9F;
+  color: #ffffff;
+}
+.palette-Indigo-700.text {
+  color: #303F9F;
+}
+.palette-Indigo-700-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-700-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-700-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-700-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-700-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-700-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-800.bg {
+  background-color: #283593;
+  color: #ffffff;
+}
+.palette-Indigo-800.text {
+  color: #283593;
+}
+.palette-Indigo-800-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-800-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-800-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-800-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-800-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-800-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-900.bg {
+  background-color: #1A237E;
+  color: #ffffff;
+}
+.palette-Indigo-900.text {
+  color: #1A237E;
+}
+.palette-Indigo-900-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-900-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-900-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-900-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-900-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-900-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-A100.bg {
+  background-color: #8C9EFF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Indigo-A100.text {
+  color: #8C9EFF;
+}
+.palette-Indigo-A100-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-A100-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-A100-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A100-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A100-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A100-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-A200.bg {
+  background-color: #536DFE;
+  color: #ffffff;
+}
+.palette-Indigo-A200.text {
+  color: #536DFE;
+}
+.palette-Indigo-A200-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-A200-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-A200-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A200-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A200-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A200-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-A400.bg {
+  background-color: #3D5AFE;
+  color: #ffffff;
+}
+.palette-Indigo-A400.text {
+  color: #3D5AFE;
+}
+.palette-Indigo-A400-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-A400-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-A400-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A400-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A400-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A400-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Indigo-A700.bg {
+  background-color: #304FFE;
+  color: #ffffff;
+}
+.palette-Indigo-A700.text {
+  color: #304FFE;
+}
+.palette-Indigo-A700-Primary.bg {
+  background-color: #3F51B5;
+  color: #ffffff;
+}
+.palette-Indigo-A700-Secondary.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Indigo-A700-Icons.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A700-Disabled.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A700-Hint.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Indigo-A700-Dividers.bg {
+  background-color: #3F51B5;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Blue.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue.text {
+  color: #2196F3;
+}
+.palette-Blue-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-50.bg {
+  background-color: #E3F2FD;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-50.text {
+  color: #E3F2FD;
+}
+.palette-Blue-50-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-50-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-50-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-50-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-50-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-50-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-100.bg {
+  background-color: #BBDEFB;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-100.text {
+  color: #BBDEFB;
+}
+.palette-Blue-100-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-100-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-100-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-100-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-100-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-100-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-200.bg {
+  background-color: #90CAF9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-200.text {
+  color: #90CAF9;
+}
+.palette-Blue-200-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-200-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-200-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-200-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-200-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-200-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-300.bg {
+  background-color: #64B5F6;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-300.text {
+  color: #64B5F6;
+}
+.palette-Blue-300-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-300-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-300-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-300-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-300-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-300-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-400.bg {
+  background-color: #42A5F5;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-400.text {
+  color: #42A5F5;
+}
+.palette-Blue-400-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-400-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-400-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-400-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-400-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-400-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-500.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-500.text {
+  color: #2196F3;
+}
+.palette-Blue-500-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-500-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-500-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-500-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-500-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-500-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-600.bg {
+  background-color: #1E88E5;
+  color: #ffffff;
+}
+.palette-Blue-600.text {
+  color: #1E88E5;
+}
+.palette-Blue-600-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-600-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-600-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-600-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-600-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-600-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-700.bg {
+  background-color: #1976D2;
+  color: #ffffff;
+}
+.palette-Blue-700.text {
+  color: #1976D2;
+}
+.palette-Blue-700-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-700-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-700-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-700-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-700-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-700-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-800.bg {
+  background-color: #1565C0;
+  color: #ffffff;
+}
+.palette-Blue-800.text {
+  color: #1565C0;
+}
+.palette-Blue-800-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-800-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-800-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-800-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-800-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-800-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-900.bg {
+  background-color: #0D47A1;
+  color: #ffffff;
+}
+.palette-Blue-900.text {
+  color: #0D47A1;
+}
+.palette-Blue-900-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-900-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-900-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-900-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-900-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-900-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-A100.bg {
+  background-color: #82B1FF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-A100.text {
+  color: #82B1FF;
+}
+.palette-Blue-A100-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-A100-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-A100-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A100-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A100-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A100-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-A200.bg {
+  background-color: #448AFF;
+  color: #ffffff;
+}
+.palette-Blue-A200.text {
+  color: #448AFF;
+}
+.palette-Blue-A200-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-A200-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-A200-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A200-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A200-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A200-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-A400.bg {
+  background-color: #2979FF;
+  color: #ffffff;
+}
+.palette-Blue-A400.text {
+  color: #2979FF;
+}
+.palette-Blue-A400-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-A400-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-A400-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A400-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A400-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A400-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-A700.bg {
+  background-color: #2962FF;
+  color: #ffffff;
+}
+.palette-Blue-A700.text {
+  color: #2962FF;
+}
+.palette-Blue-A700-Primary.bg {
+  background-color: #2196F3;
+  color: #ffffff;
+}
+.palette-Blue-A700-Secondary.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-A700-Icons.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A700-Disabled.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A700-Hint.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-A700-Dividers.bg {
+  background-color: #2196F3;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Light-Blue.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue.text {
+  color: #03A9F4;
+}
+.palette-Light-Blue-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-50.bg {
+  background-color: #E1F5FE;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-50.text {
+  color: #E1F5FE;
+}
+.palette-Light-Blue-50-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-50-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-50-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-50-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-50-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-50-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-100.bg {
+  background-color: #B3E5FC;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-100.text {
+  color: #B3E5FC;
+}
+.palette-Light-Blue-100-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-100-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-100-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-100-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-100-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-100-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-200.bg {
+  background-color: #81D4FA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-200.text {
+  color: #81D4FA;
+}
+.palette-Light-Blue-200-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-200-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-200-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-200-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-200-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-200-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-300.bg {
+  background-color: #4FC3F7;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-300.text {
+  color: #4FC3F7;
+}
+.palette-Light-Blue-300-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-300-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-300-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-300-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-300-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-300-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-400.bg {
+  background-color: #29B6F6;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-400.text {
+  color: #29B6F6;
+}
+.palette-Light-Blue-400-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-400-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-400-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-400-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-400-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-400-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-500.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-500.text {
+  color: #03A9F4;
+}
+.palette-Light-Blue-500-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-500-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-500-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-500-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-500-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-500-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-600.bg {
+  background-color: #039BE5;
+  color: #ffffff;
+}
+.palette-Light-Blue-600.text {
+  color: #039BE5;
+}
+.palette-Light-Blue-600-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-600-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-600-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-600-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-600-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-600-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-700.bg {
+  background-color: #0288D1;
+  color: #ffffff;
+}
+.palette-Light-Blue-700.text {
+  color: #0288D1;
+}
+.palette-Light-Blue-700-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-700-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-700-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-700-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-700-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-700-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-800.bg {
+  background-color: #0277BD;
+  color: #ffffff;
+}
+.palette-Light-Blue-800.text {
+  color: #0277BD;
+}
+.palette-Light-Blue-800-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-800-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-800-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-800-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-800-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-800-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-900.bg {
+  background-color: #01579B;
+  color: #ffffff;
+}
+.palette-Light-Blue-900.text {
+  color: #01579B;
+}
+.palette-Light-Blue-900-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-900-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-900-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-900-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-900-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-900-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-A100.bg {
+  background-color: #80D8FF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A100.text {
+  color: #80D8FF;
+}
+.palette-Light-Blue-A100-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A100-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-A100-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A100-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A100-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A100-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-A200.bg {
+  background-color: #40C4FF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A200.text {
+  color: #40C4FF;
+}
+.palette-Light-Blue-A200-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A200-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-A200-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A200-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A200-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A200-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-A400.bg {
+  background-color: #00B0FF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A400.text {
+  color: #00B0FF;
+}
+.palette-Light-Blue-A400-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A400-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-A400-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A400-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A400-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A400-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Blue-A700.bg {
+  background-color: #0091EA;
+  color: #ffffff;
+}
+.palette-Light-Blue-A700.text {
+  color: #0091EA;
+}
+.palette-Light-Blue-A700-Primary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Blue-A700-Secondary.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Blue-A700-Icons.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A700-Disabled.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A700-Hint.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Blue-A700-Dividers.bg {
+  background-color: #03A9F4;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Cyan.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan.text {
+  color: #00BCD4;
+}
+.palette-Cyan-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-50.bg {
+  background-color: #E0F7FA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-50.text {
+  color: #E0F7FA;
+}
+.palette-Cyan-50-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-50-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-50-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-50-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-50-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-50-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-100.bg {
+  background-color: #B2EBF2;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-100.text {
+  color: #B2EBF2;
+}
+.palette-Cyan-100-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-100-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-100-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-100-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-100-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-100-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-200.bg {
+  background-color: #80DEEA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-200.text {
+  color: #80DEEA;
+}
+.palette-Cyan-200-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-200-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-200-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-200-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-200-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-200-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-300.bg {
+  background-color: #4DD0E1;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-300.text {
+  color: #4DD0E1;
+}
+.palette-Cyan-300-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-300-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-300-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-300-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-300-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-300-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-400.bg {
+  background-color: #26C6DA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-400.text {
+  color: #26C6DA;
+}
+.palette-Cyan-400-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-400-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-400-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-400-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-400-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-400-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-500.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-500.text {
+  color: #00BCD4;
+}
+.palette-Cyan-500-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-500-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-500-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-500-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-500-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-500-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-600.bg {
+  background-color: #00ACC1;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-600.text {
+  color: #00ACC1;
+}
+.palette-Cyan-600-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-600-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-600-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-600-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-600-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-600-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-700.bg {
+  background-color: #0097A7;
+  color: #ffffff;
+}
+.palette-Cyan-700.text {
+  color: #0097A7;
+}
+.palette-Cyan-700-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-700-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-700-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-700-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-700-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-700-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-800.bg {
+  background-color: #00838F;
+  color: #ffffff;
+}
+.palette-Cyan-800.text {
+  color: #00838F;
+}
+.palette-Cyan-800-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-800-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-800-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-800-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-800-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-800-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-900.bg {
+  background-color: #006064;
+  color: #ffffff;
+}
+.palette-Cyan-900.text {
+  color: #006064;
+}
+.palette-Cyan-900-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-900-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-900-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-900-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-900-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-900-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-A100.bg {
+  background-color: #84FFFF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A100.text {
+  color: #84FFFF;
+}
+.palette-Cyan-A100-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A100-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-A100-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A100-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A100-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A100-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-A200.bg {
+  background-color: #18FFFF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A200.text {
+  color: #18FFFF;
+}
+.palette-Cyan-A200-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A200-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-A200-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A200-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A200-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A200-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-A400.bg {
+  background-color: #00E5FF;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A400.text {
+  color: #00E5FF;
+}
+.palette-Cyan-A400-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A400-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-A400-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A400-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A400-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A400-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Cyan-A700.bg {
+  background-color: #00B8D4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A700.text {
+  color: #00B8D4;
+}
+.palette-Cyan-A700-Primary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Cyan-A700-Secondary.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Cyan-A700-Icons.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A700-Disabled.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A700-Hint.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Cyan-A700-Dividers.bg {
+  background-color: #00BCD4;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Teal.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal.text {
+  color: #009688;
+}
+.palette-Teal-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-50.bg {
+  background-color: #E0F2F1;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-50.text {
+  color: #E0F2F1;
+}
+.palette-Teal-50-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-50-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-50-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-50-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-50-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-50-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-100.bg {
+  background-color: #B2DFDB;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-100.text {
+  color: #B2DFDB;
+}
+.palette-Teal-100-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-100-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-100-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-100-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-100-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-100-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-200.bg {
+  background-color: #80CBC4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-200.text {
+  color: #80CBC4;
+}
+.palette-Teal-200-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-200-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-200-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-200-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-200-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-200-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-300.bg {
+  background-color: #4DB6AC;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-300.text {
+  color: #4DB6AC;
+}
+.palette-Teal-300-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-300-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-300-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-300-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-300-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-300-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-400.bg {
+  background-color: #26A69A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-400.text {
+  color: #26A69A;
+}
+.palette-Teal-400-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-400-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-400-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-400-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-400-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-400-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-500.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-500.text {
+  color: #009688;
+}
+.palette-Teal-500-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-500-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-500-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-500-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-500-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-500-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-600.bg {
+  background-color: #00897B;
+  color: #ffffff;
+}
+.palette-Teal-600.text {
+  color: #00897B;
+}
+.palette-Teal-600-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-600-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-600-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-600-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-600-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-600-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-700.bg {
+  background-color: #00796B;
+  color: #ffffff;
+}
+.palette-Teal-700.text {
+  color: #00796B;
+}
+.palette-Teal-700-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-700-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-700-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-700-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-700-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-700-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-800.bg {
+  background-color: #00695C;
+  color: #ffffff;
+}
+.palette-Teal-800.text {
+  color: #00695C;
+}
+.palette-Teal-800-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-800-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-800-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-800-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-800-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-800-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-900.bg {
+  background-color: #004D40;
+  color: #ffffff;
+}
+.palette-Teal-900.text {
+  color: #004D40;
+}
+.palette-Teal-900-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-900-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-900-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-900-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-900-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-900-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-A100.bg {
+  background-color: #A7FFEB;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-A100.text {
+  color: #A7FFEB;
+}
+.palette-Teal-A100-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-A100-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-A100-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A100-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A100-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A100-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-A200.bg {
+  background-color: #64FFDA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-A200.text {
+  color: #64FFDA;
+}
+.palette-Teal-A200-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-A200-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-A200-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A200-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A200-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A200-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-A400.bg {
+  background-color: #1DE9B6;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-A400.text {
+  color: #1DE9B6;
+}
+.palette-Teal-A400-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-A400-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-A400-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A400-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A400-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A400-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Teal-A700.bg {
+  background-color: #00BFA5;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Teal-A700.text {
+  color: #00BFA5;
+}
+.palette-Teal-A700-Primary.bg {
+  background-color: #009688;
+  color: #ffffff;
+}
+.palette-Teal-A700-Secondary.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Teal-A700-Icons.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A700-Disabled.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A700-Hint.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Teal-A700-Dividers.bg {
+  background-color: #009688;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Green.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green.text {
+  color: #4CAF50;
+}
+.palette-Green-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-50.bg {
+  background-color: #E8F5E9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-50.text {
+  color: #E8F5E9;
+}
+.palette-Green-50-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-50-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-50-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-50-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-50-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-50-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-100.bg {
+  background-color: #C8E6C9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-100.text {
+  color: #C8E6C9;
+}
+.palette-Green-100-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-100-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-100-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-100-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-100-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-100-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-200.bg {
+  background-color: #A5D6A7;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-200.text {
+  color: #A5D6A7;
+}
+.palette-Green-200-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-200-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-200-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-200-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-200-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-200-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-300.bg {
+  background-color: #81C784;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-300.text {
+  color: #81C784;
+}
+.palette-Green-300-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-300-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-300-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-300-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-300-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-300-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-400.bg {
+  background-color: #66BB6A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-400.text {
+  color: #66BB6A;
+}
+.palette-Green-400-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-400-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-400-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-400-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-400-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-400-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-500.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-500.text {
+  color: #4CAF50;
+}
+.palette-Green-500-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-500-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-500-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-500-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-500-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-500-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-600.bg {
+  background-color: #43A047;
+  color: #ffffff;
+}
+.palette-Green-600.text {
+  color: #43A047;
+}
+.palette-Green-600-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-600-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-600-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-600-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-600-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-600-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-700.bg {
+  background-color: #388E3C;
+  color: #ffffff;
+}
+.palette-Green-700.text {
+  color: #388E3C;
+}
+.palette-Green-700-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-700-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-700-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-700-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-700-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-700-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-800.bg {
+  background-color: #2E7D32;
+  color: #ffffff;
+}
+.palette-Green-800.text {
+  color: #2E7D32;
+}
+.palette-Green-800-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-800-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-800-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-800-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-800-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-800-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-900.bg {
+  background-color: #1B5E20;
+  color: #ffffff;
+}
+.palette-Green-900.text {
+  color: #1B5E20;
+}
+.palette-Green-900-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-900-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-900-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-900-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-900-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-900-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-A100.bg {
+  background-color: #B9F6CA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A100.text {
+  color: #B9F6CA;
+}
+.palette-Green-A100-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A100-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-A100-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A100-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A100-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A100-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-A200.bg {
+  background-color: #69F0AE;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A200.text {
+  color: #69F0AE;
+}
+.palette-Green-A200-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A200-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-A200-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A200-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A200-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A200-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-A400.bg {
+  background-color: #00E676;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A400.text {
+  color: #00E676;
+}
+.palette-Green-A400-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A400-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-A400-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A400-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A400-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A400-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Green-A700.bg {
+  background-color: #00C853;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A700.text {
+  color: #00C853;
+}
+.palette-Green-A700-Primary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Green-A700-Secondary.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Green-A700-Icons.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A700-Disabled.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A700-Hint.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Green-A700-Dividers.bg {
+  background-color: #4CAF50;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Light-Green.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green.text {
+  color: #8BC34A;
+}
+.palette-Light-Green-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-50.bg {
+  background-color: #F1F8E9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-50.text {
+  color: #F1F8E9;
+}
+.palette-Light-Green-50-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-50-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-50-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-50-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-50-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-50-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-100.bg {
+  background-color: #DCEDC8;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-100.text {
+  color: #DCEDC8;
+}
+.palette-Light-Green-100-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-100-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-100-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-100-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-100-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-100-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-200.bg {
+  background-color: #C5E1A5;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-200.text {
+  color: #C5E1A5;
+}
+.palette-Light-Green-200-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-200-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-200-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-200-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-200-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-200-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-300.bg {
+  background-color: #AED581;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-300.text {
+  color: #AED581;
+}
+.palette-Light-Green-300-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-300-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-300-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-300-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-300-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-300-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-400.bg {
+  background-color: #9CCC65;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-400.text {
+  color: #9CCC65;
+}
+.palette-Light-Green-400-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-400-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-400-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-400-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-400-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-400-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-500.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-500.text {
+  color: #8BC34A;
+}
+.palette-Light-Green-500-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-500-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-500-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-500-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-500-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-500-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-600.bg {
+  background-color: #7CB342;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-600.text {
+  color: #7CB342;
+}
+.palette-Light-Green-600-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-600-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-600-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-600-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-600-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-600-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-700.bg {
+  background-color: #689F38;
+  color: #ffffff;
+}
+.palette-Light-Green-700.text {
+  color: #689F38;
+}
+.palette-Light-Green-700-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-700-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-700-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-700-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-700-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-700-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-800.bg {
+  background-color: #558B2F;
+  color: #ffffff;
+}
+.palette-Light-Green-800.text {
+  color: #558B2F;
+}
+.palette-Light-Green-800-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-800-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-800-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-800-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-800-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-800-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-900.bg {
+  background-color: #33691E;
+  color: #ffffff;
+}
+.palette-Light-Green-900.text {
+  color: #33691E;
+}
+.palette-Light-Green-900-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-900-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-900-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-900-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-900-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-900-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-A100.bg {
+  background-color: #CCFF90;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A100.text {
+  color: #CCFF90;
+}
+.palette-Light-Green-A100-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A100-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-A100-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A100-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A100-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A100-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-A200.bg {
+  background-color: #B2FF59;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A200.text {
+  color: #B2FF59;
+}
+.palette-Light-Green-A200-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A200-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-A200-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A200-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A200-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A200-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-A400.bg {
+  background-color: #76FF03;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A400.text {
+  color: #76FF03;
+}
+.palette-Light-Green-A400-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A400-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-A400-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A400-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A400-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A400-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Light-Green-A700.bg {
+  background-color: #64DD17;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A700.text {
+  color: #64DD17;
+}
+.palette-Light-Green-A700-Primary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Light-Green-A700-Secondary.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Light-Green-A700-Icons.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A700-Disabled.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A700-Hint.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Light-Green-A700-Dividers.bg {
+  background-color: #8BC34A;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Lime.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime.text {
+  color: #CDDC39;
+}
+.palette-Lime-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-50.bg {
+  background-color: #F9FBE7;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-50.text {
+  color: #F9FBE7;
+}
+.palette-Lime-50-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-50-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-50-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-50-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-50-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-50-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-100.bg {
+  background-color: #F0F4C3;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-100.text {
+  color: #F0F4C3;
+}
+.palette-Lime-100-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-100-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-100-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-100-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-100-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-100-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-200.bg {
+  background-color: #E6EE9C;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-200.text {
+  color: #E6EE9C;
+}
+.palette-Lime-200-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-200-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-200-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-200-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-200-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-200-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-300.bg {
+  background-color: #DCE775;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-300.text {
+  color: #DCE775;
+}
+.palette-Lime-300-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-300-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-300-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-300-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-300-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-300-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-400.bg {
+  background-color: #D4E157;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-400.text {
+  color: #D4E157;
+}
+.palette-Lime-400-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-400-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-400-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-400-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-400-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-400-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-500.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-500.text {
+  color: #CDDC39;
+}
+.palette-Lime-500-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-500-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-500-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-500-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-500-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-500-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-600.bg {
+  background-color: #C0CA33;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-600.text {
+  color: #C0CA33;
+}
+.palette-Lime-600-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-600-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-600-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-600-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-600-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-600-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-700.bg {
+  background-color: #AFB42B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-700.text {
+  color: #AFB42B;
+}
+.palette-Lime-700-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-700-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-700-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-700-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-700-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-700-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-800.bg {
+  background-color: #9E9D24;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-800.text {
+  color: #9E9D24;
+}
+.palette-Lime-800-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-800-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-800-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-800-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-800-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-800-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-900.bg {
+  background-color: #827717;
+  color: #ffffff;
+}
+.palette-Lime-900.text {
+  color: #827717;
+}
+.palette-Lime-900-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-900-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-900-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-900-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-900-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-900-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-A100.bg {
+  background-color: #F4FF81;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A100.text {
+  color: #F4FF81;
+}
+.palette-Lime-A100-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A100-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-A100-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A100-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A100-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A100-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-A200.bg {
+  background-color: #EEFF41;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A200.text {
+  color: #EEFF41;
+}
+.palette-Lime-A200-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A200-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-A200-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A200-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A200-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A200-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-A400.bg {
+  background-color: #C6FF00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A400.text {
+  color: #C6FF00;
+}
+.palette-Lime-A400-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A400-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-A400-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A400-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A400-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A400-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Lime-A700.bg {
+  background-color: #AEEA00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A700.text {
+  color: #AEEA00;
+}
+.palette-Lime-A700-Primary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Lime-A700-Secondary.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Lime-A700-Icons.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A700-Disabled.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A700-Hint.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Lime-A700-Dividers.bg {
+  background-color: #CDDC39;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Yellow.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow.text {
+  color: #FFEB3B;
+}
+.palette-Yellow-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-50.bg {
+  background-color: #FFFDE7;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-50.text {
+  color: #FFFDE7;
+}
+.palette-Yellow-50-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-50-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-50-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-50-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-50-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-50-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-100.bg {
+  background-color: #FFF9C4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-100.text {
+  color: #FFF9C4;
+}
+.palette-Yellow-100-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-100-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-100-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-100-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-100-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-100-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-200.bg {
+  background-color: #FFF59D;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-200.text {
+  color: #FFF59D;
+}
+.palette-Yellow-200-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-200-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-200-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-200-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-200-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-200-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-300.bg {
+  background-color: #FFF176;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-300.text {
+  color: #FFF176;
+}
+.palette-Yellow-300-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-300-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-300-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-300-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-300-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-300-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-400.bg {
+  background-color: #FFEE58;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-400.text {
+  color: #FFEE58;
+}
+.palette-Yellow-400-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-400-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-400-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-400-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-400-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-400-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-500.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-500.text {
+  color: #FFEB3B;
+}
+.palette-Yellow-500-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-500-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-500-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-500-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-500-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-500-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-600.bg {
+  background-color: #FDD835;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-600.text {
+  color: #FDD835;
+}
+.palette-Yellow-600-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-600-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-600-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-600-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-600-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-600-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-700.bg {
+  background-color: #FBC02D;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-700.text {
+  color: #FBC02D;
+}
+.palette-Yellow-700-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-700-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-700-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-700-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-700-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-700-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-800.bg {
+  background-color: #F9A825;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-800.text {
+  color: #F9A825;
+}
+.palette-Yellow-800-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-800-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-800-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-800-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-800-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-800-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-900.bg {
+  background-color: #F57F17;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-900.text {
+  color: #F57F17;
+}
+.palette-Yellow-900-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-900-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-900-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-900-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-900-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-900-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-A100.bg {
+  background-color: #FFFF8D;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A100.text {
+  color: #FFFF8D;
+}
+.palette-Yellow-A100-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A100-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-A100-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A100-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A100-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A100-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-A200.bg {
+  background-color: #FFFF00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A200.text {
+  color: #FFFF00;
+}
+.palette-Yellow-A200-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A200-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-A200-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A200-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A200-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A200-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-A400.bg {
+  background-color: #FFEA00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A400.text {
+  color: #FFEA00;
+}
+.palette-Yellow-A400-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A400-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-A400-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A400-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A400-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A400-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Yellow-A700.bg {
+  background-color: #FFD600;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A700.text {
+  color: #FFD600;
+}
+.palette-Yellow-A700-Primary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Yellow-A700-Secondary.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Yellow-A700-Icons.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A700-Disabled.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A700-Hint.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Yellow-A700-Dividers.bg {
+  background-color: #FFEB3B;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Amber.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber.text {
+  color: #FFC107;
+}
+.palette-Amber-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-50.bg {
+  background-color: #FFF8E1;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-50.text {
+  color: #FFF8E1;
+}
+.palette-Amber-50-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-50-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-50-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-50-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-50-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-50-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-100.bg {
+  background-color: #FFECB3;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-100.text {
+  color: #FFECB3;
+}
+.palette-Amber-100-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-100-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-100-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-100-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-100-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-100-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-200.bg {
+  background-color: #FFE082;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-200.text {
+  color: #FFE082;
+}
+.palette-Amber-200-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-200-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-200-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-200-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-200-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-200-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-300.bg {
+  background-color: #FFD54F;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-300.text {
+  color: #FFD54F;
+}
+.palette-Amber-300-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-300-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-300-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-300-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-300-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-300-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-400.bg {
+  background-color: #FFCA28;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-400.text {
+  color: #FFCA28;
+}
+.palette-Amber-400-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-400-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-400-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-400-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-400-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-400-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-500.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-500.text {
+  color: #FFC107;
+}
+.palette-Amber-500-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-500-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-500-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-500-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-500-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-500-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-600.bg {
+  background-color: #FFB300;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-600.text {
+  color: #FFB300;
+}
+.palette-Amber-600-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-600-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-600-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-600-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-600-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-600-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-700.bg {
+  background-color: #FFA000;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-700.text {
+  color: #FFA000;
+}
+.palette-Amber-700-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-700-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-700-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-700-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-700-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-700-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-800.bg {
+  background-color: #FF8F00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-800.text {
+  color: #FF8F00;
+}
+.palette-Amber-800-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-800-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-800-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-800-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-800-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-800-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-900.bg {
+  background-color: #FF6F00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-900.text {
+  color: #FF6F00;
+}
+.palette-Amber-900-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-900-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-900-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-900-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-900-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-900-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-A100.bg {
+  background-color: #FFE57F;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A100.text {
+  color: #FFE57F;
+}
+.palette-Amber-A100-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A100-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-A100-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A100-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A100-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A100-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-A200.bg {
+  background-color: #FFD740;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A200.text {
+  color: #FFD740;
+}
+.palette-Amber-A200-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A200-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-A200-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A200-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A200-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A200-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-A400.bg {
+  background-color: #FFC400;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A400.text {
+  color: #FFC400;
+}
+.palette-Amber-A400-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A400-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-A400-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A400-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A400-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A400-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Amber-A700.bg {
+  background-color: #FFAB00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A700.text {
+  color: #FFAB00;
+}
+.palette-Amber-A700-Primary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Amber-A700-Secondary.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Amber-A700-Icons.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A700-Disabled.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A700-Hint.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Amber-A700-Dividers.bg {
+  background-color: #FFC107;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Orange.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange.text {
+  color: #FF9800;
+}
+.palette-Orange-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-50.bg {
+  background-color: #FFF3E0;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-50.text {
+  color: #FFF3E0;
+}
+.palette-Orange-50-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-50-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-50-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-50-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-50-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-50-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-100.bg {
+  background-color: #FFE0B2;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-100.text {
+  color: #FFE0B2;
+}
+.palette-Orange-100-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-100-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-100-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-100-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-100-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-100-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-200.bg {
+  background-color: #FFCC80;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-200.text {
+  color: #FFCC80;
+}
+.palette-Orange-200-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-200-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-200-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-200-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-200-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-200-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-300.bg {
+  background-color: #FFB74D;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-300.text {
+  color: #FFB74D;
+}
+.palette-Orange-300-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-300-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-300-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-300-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-300-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-300-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-400.bg {
+  background-color: #FFA726;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-400.text {
+  color: #FFA726;
+}
+.palette-Orange-400-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-400-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-400-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-400-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-400-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-400-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-500.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-500.text {
+  color: #FF9800;
+}
+.palette-Orange-500-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-500-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-500-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-500-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-500-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-500-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-600.bg {
+  background-color: #FB8C00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-600.text {
+  color: #FB8C00;
+}
+.palette-Orange-600-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-600-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-600-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-600-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-600-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-600-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-700.bg {
+  background-color: #F57C00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-700.text {
+  color: #F57C00;
+}
+.palette-Orange-700-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-700-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-700-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-700-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-700-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-700-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-800.bg {
+  background-color: #EF6C00;
+  color: #ffffff;
+}
+.palette-Orange-800.text {
+  color: #EF6C00;
+}
+.palette-Orange-800-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-800-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-800-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-800-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-800-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-800-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-900.bg {
+  background-color: #E65100;
+  color: #ffffff;
+}
+.palette-Orange-900.text {
+  color: #E65100;
+}
+.palette-Orange-900-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-900-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-900-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-900-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-900-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-900-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-A100.bg {
+  background-color: #FFD180;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A100.text {
+  color: #FFD180;
+}
+.palette-Orange-A100-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A100-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-A100-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A100-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A100-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A100-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-A200.bg {
+  background-color: #FFAB40;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A200.text {
+  color: #FFAB40;
+}
+.palette-Orange-A200-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A200-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-A200-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A200-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A200-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A200-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-A400.bg {
+  background-color: #FF9100;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A400.text {
+  color: #FF9100;
+}
+.palette-Orange-A400-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A400-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-A400-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A400-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A400-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A400-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Orange-A700.bg {
+  background-color: #FF6D00;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A700.text {
+  color: #FF6D00;
+}
+.palette-Orange-A700-Primary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Orange-A700-Secondary.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Orange-A700-Icons.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A700-Disabled.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A700-Hint.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Orange-A700-Dividers.bg {
+  background-color: #FF9800;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Deep-Orange.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange.text {
+  color: #FF5722;
+}
+.palette-Deep-Orange-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-50.bg {
+  background-color: #FBE9E7;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-50.text {
+  color: #FBE9E7;
+}
+.palette-Deep-Orange-50-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-50-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-50-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-50-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-50-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-50-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-100.bg {
+  background-color: #FFCCBC;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-100.text {
+  color: #FFCCBC;
+}
+.palette-Deep-Orange-100-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-100-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-100-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-100-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-100-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-100-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-200.bg {
+  background-color: #FFAB91;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-200.text {
+  color: #FFAB91;
+}
+.palette-Deep-Orange-200-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-200-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-200-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-200-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-200-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-200-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-300.bg {
+  background-color: #FF8A65;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-300.text {
+  color: #FF8A65;
+}
+.palette-Deep-Orange-300-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-300-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-300-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-300-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-300-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-300-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-400.bg {
+  background-color: #FF7043;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-400.text {
+  color: #FF7043;
+}
+.palette-Deep-Orange-400-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-400-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-400-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-400-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-400-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-400-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-500.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-500.text {
+  color: #FF5722;
+}
+.palette-Deep-Orange-500-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-500-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-500-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-500-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-500-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-500-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-600.bg {
+  background-color: #F4511E;
+  color: #ffffff;
+}
+.palette-Deep-Orange-600.text {
+  color: #F4511E;
+}
+.palette-Deep-Orange-600-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-600-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-600-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-600-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-600-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-600-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-700.bg {
+  background-color: #E64A19;
+  color: #ffffff;
+}
+.palette-Deep-Orange-700.text {
+  color: #E64A19;
+}
+.palette-Deep-Orange-700-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-700-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-700-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-700-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-700-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-700-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-800.bg {
+  background-color: #D84315;
+  color: #ffffff;
+}
+.palette-Deep-Orange-800.text {
+  color: #D84315;
+}
+.palette-Deep-Orange-800-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-800-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-800-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-800-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-800-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-800-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-900.bg {
+  background-color: #BF360C;
+  color: #ffffff;
+}
+.palette-Deep-Orange-900.text {
+  color: #BF360C;
+}
+.palette-Deep-Orange-900-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-900-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-900-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-900-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-900-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-900-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-A100.bg {
+  background-color: #FF9E80;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-A100.text {
+  color: #FF9E80;
+}
+.palette-Deep-Orange-A100-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-A100-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-A100-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A100-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A100-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A100-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-A200.bg {
+  background-color: #FF6E40;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Deep-Orange-A200.text {
+  color: #FF6E40;
+}
+.palette-Deep-Orange-A200-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-A200-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-A200-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A200-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A200-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A200-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-A400.bg {
+  background-color: #FF3D00;
+  color: #ffffff;
+}
+.palette-Deep-Orange-A400.text {
+  color: #FF3D00;
+}
+.palette-Deep-Orange-A400-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-A400-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-A400-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A400-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A400-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A400-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Deep-Orange-A700.bg {
+  background-color: #DD2C00;
+  color: #ffffff;
+}
+.palette-Deep-Orange-A700.text {
+  color: #DD2C00;
+}
+.palette-Deep-Orange-A700-Primary.bg {
+  background-color: #FF5722;
+  color: #ffffff;
+}
+.palette-Deep-Orange-A700-Secondary.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Deep-Orange-A700-Icons.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A700-Disabled.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A700-Hint.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Deep-Orange-A700-Dividers.bg {
+  background-color: #FF5722;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Brown.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown.text {
+  color: #795548;
+}
+.palette-Brown-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-50.bg {
+  background-color: #EFEBE9;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Brown-50.text {
+  color: #EFEBE9;
+}
+.palette-Brown-50-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-50-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-50-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-50-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-50-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-50-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-100.bg {
+  background-color: #D7CCC8;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Brown-100.text {
+  color: #D7CCC8;
+}
+.palette-Brown-100-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-100-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-100-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-100-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-100-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-100-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-200.bg {
+  background-color: #BCAAA4;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Brown-200.text {
+  color: #BCAAA4;
+}
+.palette-Brown-200-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-200-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-200-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-200-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-200-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-200-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-300.bg {
+  background-color: #A1887F;
+  color: #ffffff;
+}
+.palette-Brown-300.text {
+  color: #A1887F;
+}
+.palette-Brown-300-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-300-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-300-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-300-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-300-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-300-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-400.bg {
+  background-color: #8D6E63;
+  color: #ffffff;
+}
+.palette-Brown-400.text {
+  color: #8D6E63;
+}
+.palette-Brown-400-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-400-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-400-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-400-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-400-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-400-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-500.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-500.text {
+  color: #795548;
+}
+.palette-Brown-500-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-500-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-500-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-500-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-500-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-500-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-600.bg {
+  background-color: #6D4C41;
+  color: #ffffff;
+}
+.palette-Brown-600.text {
+  color: #6D4C41;
+}
+.palette-Brown-600-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-600-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-600-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-600-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-600-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-600-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-700.bg {
+  background-color: #5D4037;
+  color: #ffffff;
+}
+.palette-Brown-700.text {
+  color: #5D4037;
+}
+.palette-Brown-700-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-700-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-700-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-700-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-700-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-700-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-800.bg {
+  background-color: #4E342E;
+  color: #ffffff;
+}
+.palette-Brown-800.text {
+  color: #4E342E;
+}
+.palette-Brown-800-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-800-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-800-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-800-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-800-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-800-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Brown-900.bg {
+  background-color: #3E2723;
+  color: #ffffff;
+}
+.palette-Brown-900.text {
+  color: #3E2723;
+}
+.palette-Brown-900-Primary.bg {
+  background-color: #795548;
+  color: #ffffff;
+}
+.palette-Brown-900-Secondary.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Brown-900-Icons.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-900-Disabled.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-900-Hint.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Brown-900-Dividers.bg {
+  background-color: #795548;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Grey.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey.text {
+  color: #9E9E9E;
+}
+.palette-Grey-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-50.bg {
+  background-color: #FAFAFA;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-50.text {
+  color: #FAFAFA;
+}
+.palette-Grey-50-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-50-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-50-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-50-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-50-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-50-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-100.bg {
+  background-color: #F5F5F5;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-100.text {
+  color: #F5F5F5;
+}
+.palette-Grey-100-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-100-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-100-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-100-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-100-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-100-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-200.bg {
+  background-color: #EEEEEE;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-200.text {
+  color: #EEEEEE;
+}
+.palette-Grey-200-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-200-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-200-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-200-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-200-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-200-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-300.bg {
+  background-color: #E0E0E0;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-300.text {
+  color: #E0E0E0;
+}
+.palette-Grey-300-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-300-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-300-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-300-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-300-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-300-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-400.bg {
+  background-color: #BDBDBD;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-400.text {
+  color: #BDBDBD;
+}
+.palette-Grey-400-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-400-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-400-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-400-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-400-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-400-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-500.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-500.text {
+  color: #9E9E9E;
+}
+.palette-Grey-500-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-500-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-500-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-500-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-500-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-500-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-600.bg {
+  background-color: #757575;
+  color: #ffffff;
+}
+.palette-Grey-600.text {
+  color: #757575;
+}
+.palette-Grey-600-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-600-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-600-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-600-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-600-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-600-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-700.bg {
+  background-color: #616161;
+  color: #ffffff;
+}
+.palette-Grey-700.text {
+  color: #616161;
+}
+.palette-Grey-700-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-700-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-700-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-700-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-700-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-700-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-800.bg {
+  background-color: #424242;
+  color: #ffffff;
+}
+.palette-Grey-800.text {
+  color: #424242;
+}
+.palette-Grey-800-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-800-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-800-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-800-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-800-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-800-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-Grey-900.bg {
+  background-color: #212121;
+  color: #ffffff;
+}
+.palette-Grey-900.text {
+  color: #212121;
+}
+.palette-Grey-900-Primary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Grey-900-Secondary.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.54);
+}
+.palette-Grey-900-Icons.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-900-Disabled.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-900-Hint.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.38);
+}
+.palette-Grey-900-Dividers.bg {
+  background-color: #9E9E9E;
+  color: rgba(0,0,0,0.12);
+}
+
+
+.palette-Blue-Grey.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey.text {
+  color: #607D8B;
+}
+.palette-Blue-Grey-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-50.bg {
+  background-color: #ECEFF1;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-Grey-50.text {
+  color: #ECEFF1;
+}
+.palette-Blue-Grey-50-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-50-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-50-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-50-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-50-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-50-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-100.bg {
+  background-color: #CFD8DC;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-Grey-100.text {
+  color: #CFD8DC;
+}
+.palette-Blue-Grey-100-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-100-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-100-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-100-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-100-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-100-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-200.bg {
+  background-color: #B0BEC5;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-Grey-200.text {
+  color: #B0BEC5;
+}
+.palette-Blue-Grey-200-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-200-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-200-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-200-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-200-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-200-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-300.bg {
+  background-color: #90A4AE;
+  color: rgba(0,0,0,0.87);
+}
+.palette-Blue-Grey-300.text {
+  color: #90A4AE;
+}
+.palette-Blue-Grey-300-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-300-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-300-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-300-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-300-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-300-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-400.bg {
+  background-color: #78909C;
+  color: #ffffff;
+}
+.palette-Blue-Grey-400.text {
+  color: #78909C;
+}
+.palette-Blue-Grey-400-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-400-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-400-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-400-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-400-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-400-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-500.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-500.text {
+  color: #607D8B;
+}
+.palette-Blue-Grey-500-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-500-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-500-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-500-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-500-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-500-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-600.bg {
+  background-color: #546E7A;
+  color: #ffffff;
+}
+.palette-Blue-Grey-600.text {
+  color: #546E7A;
+}
+.palette-Blue-Grey-600-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-600-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-600-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-600-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-600-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-600-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-700.bg {
+  background-color: #455A64;
+  color: #ffffff;
+}
+.palette-Blue-Grey-700.text {
+  color: #455A64;
+}
+.palette-Blue-Grey-700-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-700-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-700-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-700-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-700-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-700-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-800.bg {
+  background-color: #37474F;
+  color: #ffffff;
+}
+.palette-Blue-Grey-800.text {
+  color: #37474F;
+}
+.palette-Blue-Grey-800-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-800-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-800-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-800-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-800-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-800-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Blue-Grey-900.bg {
+  background-color: #263238;
+  color: #ffffff;
+}
+.palette-Blue-Grey-900.text {
+  color: #263238;
+}
+.palette-Blue-Grey-900-Primary.bg {
+  background-color: #607D8B;
+  color: #ffffff;
+}
+.palette-Blue-Grey-900-Secondary.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Blue-Grey-900-Icons.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-900-Disabled.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-900-Hint.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Blue-Grey-900-Dividers.bg {
+  background-color: #607D8B;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-Black.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black.text {
+  color: #000000;
+}
+.palette-Black-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-500.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-500.text {
+  color: #000000;
+}
+.palette-Black-500-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-500-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-500-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-500-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-500-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-500-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-text.bg {
+  background-color: rgba(0,0,0,0.87);
+  color: #ffffff;
+}
+.palette-Black-text.text {
+  color: rgba(0,0,0,0.87);
+}
+.palette-Black-text-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-text-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-text-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-text-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-text-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-text-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-Primary.bg {
+  background-color: rgba(0,0,0,0.87);
+  color: #ffffff;
+}
+.palette-Black-Primary.text {
+  color: rgba(0,0,0,0.87);
+}
+.palette-Black-Primary-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Primary-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Primary-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Primary-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Primary-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Primary-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-Secondary.bg {
+  background-color: rgba(0,0,0,0.54);
+  color: #ffffff;
+}
+.palette-Black-Secondary.text {
+  color: rgba(0,0,0,0.54);
+}
+.palette-Black-Secondary-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Secondary-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Secondary-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Secondary-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Secondary-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Secondary-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-Icons.bg {
+  background-color: rgba(0,0,0,0.38);
+  color: #ffffff;
+}
+.palette-Black-Icons.text {
+  color: rgba(0,0,0,0.38);
+}
+.palette-Black-Icons-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Icons-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Icons-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Icons-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Icons-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Icons-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-Disabled.bg {
+  background-color: rgba(0,0,0,0.38);
+  color: #ffffff;
+}
+.palette-Black-Disabled.text {
+  color: rgba(0,0,0,0.38);
+}
+.palette-Black-Disabled-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Disabled-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Disabled-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Disabled-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Disabled-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Disabled-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-Hint.bg {
+  background-color: rgba(0,0,0,0.38);
+  color: #ffffff;
+}
+.palette-Black-Hint.text {
+  color: rgba(0,0,0,0.38);
+}
+.palette-Black-Hint-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Hint-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Hint-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Hint-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Hint-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Hint-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+.palette-Black-Dividers.bg {
+  background-color: rgba(0,0,0,0.12);
+  color: #ffffff;
+}
+.palette-Black-Dividers.text {
+  color: rgba(0,0,0,0.12);
+}
+.palette-Black-Dividers-Primary.bg {
+  background-color: #000000;
+  color: #ffffff;
+}
+.palette-Black-Dividers-Secondary.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.7);
+}
+.palette-Black-Dividers-Icons.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Dividers-Disabled.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Dividers-Hint.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.5);
+}
+.palette-Black-Dividers-Dividers.bg {
+  background-color: #000000;
+  color: rgba(255,255,255,0.12);
+}
+
+
+.palette-White.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White.text {
+  color: #ffffff;
+}
+.palette-White-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-500.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-500.text {
+  color: #ffffff;
+}
+.palette-White-500-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-500-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-500-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-500-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-500-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-500-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-text.bg {
+  background-color: #ffffff;
+  color: #ffffff;
+}
+.palette-White-text.text {
+  color: #ffffff;
+}
+.palette-White-text-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-text-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-text-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-text-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-text-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-text-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Primary.text {
+  color: #ffffff;
+}
+.palette-White-Primary-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Primary-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Primary-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Primary-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Primary-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Primary-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-Secondary.bg {
+  background-color: rgba(255,255,255,0.7);
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Secondary.text {
+  color: rgba(255,255,255,0.7);
+}
+.palette-White-Secondary-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Secondary-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Secondary-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Secondary-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Secondary-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Secondary-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-Icons.bg {
+  background-color: rgba(255,255,255,0.5);
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Icons.text {
+  color: rgba(255,255,255,0.5);
+}
+.palette-White-Icons-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Icons-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Icons-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Icons-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Icons-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Icons-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-Disabled.bg {
+  background-color: rgba(255,255,255,0.5);
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Disabled.text {
+  color: rgba(255,255,255,0.5);
+}
+.palette-White-Disabled-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Disabled-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Disabled-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Disabled-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Disabled-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Disabled-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-Hint.bg {
+  background-color: rgba(255,255,255,0.5);
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Hint.text {
+  color: rgba(255,255,255,0.5);
+}
+.palette-White-Hint-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Hint-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Hint-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Hint-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Hint-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Hint-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+.palette-White-Dividers.bg {
+  background-color: rgba(255,255,255,0.12);
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Dividers.text {
+  color: rgba(255,255,255,0.12);
+}
+.palette-White-Dividers-Primary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.87);
+}
+.palette-White-Dividers-Secondary.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.54);
+}
+.palette-White-Dividers-Icons.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Dividers-Disabled.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Dividers-Hint.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.38);
+}
+.palette-White-Dividers-Dividers.bg {
+  background-color: #ffffff;
+  color: rgba(0,0,0,0.12);
+}
+
+
+

--- a/resources/assets/sass/lara.scss
+++ b/resources/assets/sass/lara.scss
@@ -6,3 +6,4 @@
 @import "../css/print.css";
 @import "event/createEdit";
 @import "../css/monthViewResponsive.css";
+@import "../css/palette.css";

--- a/resources/views/clubEventView.blade.php
+++ b/resources/views/clubEventView.blade.php
@@ -6,29 +6,24 @@
     <div class="panelEventView">
 		<div class="row no-margin">
 			<div class="panel col-xs-12 col-md-6 no-padding">
-				@if	($clubEvent->evnt_type === 1 AND $clubEvent->evnt_is_private)
-					<div class="panel panel-heading calendar-internal-info white-text">
-				@elseif     ($clubEvent->evnt_type === 1)
-					<div class="panel panel-heading calendar-public-info white-text">
-
-				@elseif (($clubEvent->evnt_type === 6 OR $clubEvent->evnt_type === 9) AND $clubEvent->evnt_is_private)
-					<div class="panel panel-heading calendar-internal-task white-text">
-				@elseif ($clubEvent->evnt_type === 6 OR $clubEvent->evnt_type === 9)
-					<div class="panel panel-heading calendar-public-task white-text">
-
-
-				@elseif (($clubEvent->evnt_type === 7 OR $clubEvent->evnt_type === 8) AND $clubEvent->evnt_is_private)
-					<div class="panel panel-heading calendar-internal-marketing white-text">
-				@elseif ($clubEvent->evnt_type === 7 OR $clubEvent->evnt_type === 8)
-					<div class="panel panel-heading calendar-public-marketing white-text">
-				@elseif ($clubEvent->evnt_is_private && !is_null($clubEvent->section))
-					<div class="panel panel-heading calendar-internal-event-{{$clubEvent->section->title}} white-text">
-				@elseif (!is_null($clubEvent->section))
-					<div class="panel panel-heading calendar-public-event-{{$clubEvent->section->title}} white-text">
-				@else
-					{{-- DEFAULT --}}
-					<div class="panel panel-heading white-text">
-				@endif
+				{{-- Set panel color --}}
+				@if     ($clubEvent->evnt_type == 0)
+			        <div class="panel panel-heading palette-{!! $clubEvent->section->color !!}-700 bg">
+			    @elseif ($clubEvent->evnt_type == 1)
+			        <div class="panel panel-heading palette-Purple-500 bg">
+			    @elseif ($clubEvent->evnt_type == 2 
+			    	  OR $clubEvent->evnt_type == 3)
+			        <div class="panel panel-heading palette-{!! $clubEvent->section->color !!}-900 bg">
+			    @elseif ($clubEvent->evnt_type == 4 
+			          OR $clubEvent->evnt_type == 5 
+			          OR $clubEvent->evnt_type == 6)
+			        <div class="panel panel-heading palette-{!! $clubEvent->section->color !!}-500 bg white-text">
+			    @elseif ($clubEvent->evnt_type == 7 
+			          OR $clubEvent->evnt_type == 8)
+			        <div class="panel panel-heading palette-{!! $clubEvent->section->color !!}-300 bg white-text">
+			    @elseif ($clubEvent->evnt_type == 9)
+			        <div class="panel panel-heading palette-{!! $clubEvent->section->color !!}-500 bg white-text">
+			    @endif
 					<h4 class="panel-title">@include("partials.event-marker")&nbsp;{{ $clubEvent->evnt_title }}</h4>
 					<h5 class="panel-title">{{ $clubEvent->evnt_subtitle }}</h5>
 				</div>

--- a/resources/views/manageSections.blade.php
+++ b/resources/views/manageSections.blade.php
@@ -41,7 +41,9 @@
 							      	</a>
 								</td>
 								<td>
-									{!! $section->color !!}
+									<span class="palette-{{$section->color}}-500-Primary bg">
+										&nbsp;&nbsp;&nbsp;&nbsp;{!! $section->color !!}&nbsp;&nbsp;&nbsp;&nbsp;
+									</span>
 								</td>
 							</tr>
 						@endforeach

--- a/resources/views/partials/month/monthCell.blade.php
+++ b/resources/views/partials/month/monthCell.blade.php
@@ -2,49 +2,50 @@
 
 @foreach($surveys as $survey) {{-- going over all surveys see weekCellSurvey for a single survey--}}
 
-{{-- check if the survey is already over --}}
-@if(strtotime($survey->deadline) < time())
-    <?php $classString = "past-eventOrSurvey"; ?>
-@else
-    <?php $classString = ""; ?>
-@endif
-
-@if(date("Y-m-d", strtotime($survey->deadline)) === date("Y-m-d", $weekDay->getTimestamp()))
-    @if(!Session::has('userId') && $survey->is_private)
-        {{-- check current session for user role && and the survey for private status--}}
-        {{-- no userId means this a guest account, so he gets blocked here--}}
-
-        {{--if so show a grey placeholder for the guest--}}
-        <div class="cal-event {{$classString}} dark-grey">
-            <i class="fa fa-bar-chart-o white-text"></i>
-            &nbsp;&nbsp;
-            {{--and show him thats a private survey(=Interne Umfrage in german) only for users--}}
-            <span class="white-text">
-                    {{ trans('mainLang.internalSurvey') }}
-                </span>
-        </div>
-
+    {{-- check if the survey is already over --}}
+    @if(strtotime($survey->deadline) < time())
+        <?php $classString = "past-eventOrSurvey"; ?>
     @else
-        {{-- meaning Session::has'userId' OR !$survey->is_private == 0--}}
-        {{-- so session has a valid user OR the guest can see this survey because it isn't private--}}
-        <div class="cal-event {{$classString}} dark-grey calendar-internal-info">
-            <i class="fa fa-bar-chart-o white-text"></i>
-            &nbsp;&nbsp;
-            {{-- provide a URL to the survey --}}
-            <a href="{{ URL::route('survey.show', $survey->id) }}"
-               data-toggle="tooltip" 
-               data-placement="right"
-               title="{{ trans('mainLang.showDetails')}}">
-                {{-- instead of private survey show the actual title of the survey --}}
-                <span class="white-text"> &nbsp;{{ $survey->title }} </span>
-            </a>
-        </div>
+        <?php $classString = ""; ?>
     @endif
-@endif
+
+    @if(date("Y-m-d", strtotime($survey->deadline)) === date("Y-m-d", $weekDay->getTimestamp()))
+        @if(!Session::has('userId') && $survey->is_private)
+            {{-- check current session for user role && and the survey for private status--}}
+            {{-- no userId means this a guest account, so he gets blocked here--}}
+
+            {{--if so show a grey placeholder for the guest--}}
+            <div class="cal-event {{$classString}} palette-Grey-500 bg">
+                <i class="fa fa-bar-chart-o white-text"></i>
+                &nbsp;&nbsp;
+                {{--and show him thats a private survey(=Interne Umfrage in german) only for users--}}
+                <span class="white-text">
+                        {{ trans('mainLang.internalSurvey') }}
+                    </span>
+            </div>
+
+        @else
+            {{-- meaning Session::has'userId' OR !$survey->is_private == 0--}}
+            {{-- so session has a valid user OR the guest can see this survey because it isn't private--}}
+            <div class="cal-event {{$classString}} palette-Grey-500 bg calendar-internal-info">
+                <i class="fa fa-bar-chart-o white-text"></i>
+                &nbsp;&nbsp;
+                {{-- provide a URL to the survey --}}
+                <a href="{{ URL::route('survey.show', $survey->id) }}"
+                   data-toggle="tooltip" 
+                   data-placement="right"
+                   title="{{ trans('mainLang.showDetails')}}">
+                    {{-- instead of private survey show the actual title of the survey --}}
+                    <span class="white-text"> &nbsp;{{ $survey->title }} </span>
+                </a>
+            </div>
+        @endif
+    @endif
 @endforeach
 
 @foreach($events as $clubEvent)
     @if($clubEvent->evnt_date_start === date("Y-m-d", $weekDay->getTimestamp()))
+ 
         {{--Check if the event is still going on--}}
         @if(strtotime($clubEvent->evnt_date_end.' '.$clubEvent->evnt_time_end) < time())
             {{-- The event is already over --}}
@@ -53,7 +54,7 @@
             <?php $classString = ""; ?>
         @endif
 
-        {{-- highlight with cal-month-my-event class if the signed in user has an shift in this event --}}
+        {{-- highlight with cal-month-my-event class if the signed in user has a shift in this event --}}
         @if((Session::has('userId') && $clubEvent->hasShift($clubEvent->getSchedule->id, Session::get('userId'))))
             <?php $classString .= " cal-month-my-event"; ?>
         @endif
@@ -66,25 +67,33 @@
             {{-- Normal scenario: add a css class according to filter data --}}
             <div class="word-break section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach">
         @endif
+
+
             {{-- guests see private events as placeholders only, so check if user is logged in --}}
             @if(!Session::has('userId'))
                 {{-- show only a placeholder for private events --}}
                 @if($clubEvent->evnt_is_private)
-                    <div class="cal-event {{$classString}} dark-grey">
+                    <div class="cal-event {{$classString}} palette-Grey-500 bg">
                         <i class="fa fa-eye-slash white-text"></i>
                         &nbsp;&nbsp;
                         <span class="white-text">{{ trans('mainLang.internEventP') }}</span>
                     </div>
                     {{-- show everything for public events --}}
                 @else
-                    @if ($clubEvent->evnt_type == 1)
-                        <div class="cal-event {{$classString}} calendar-public-info">
-                    @elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-                        <div class="cal-event {{$classString}} calendar-public-task">
-                    @elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-                        <div class="cal-event {{$classString}} calendar-public-marketing">
-                    @else
-                        <div class="cal-event {{$classString}} calendar-public-event-{{$clubEvent->section->title}}">
+                    @if     ($clubEvent->evnt_type == 0)
+                        <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-700 bg">
+                    @elseif ($clubEvent->evnt_type == 1)
+                        <div class="cal-event {{$classString}} palette-Purple-500 bg">
+                    @elseif ($clubEvent->evnt_type == 2 OR $clubEvent->evnt_type == 3)
+                        <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-900 bg">
+                    @elseif ($clubEvent->evnt_type == 4 
+                          OR $clubEvent->evnt_type == 5 
+                          OR $clubEvent->evnt_type == 6 
+                          OR $clubEvent->evnt_type == 9)
+                        <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg">
+                    @elseif ($clubEvent->evnt_type == 7 
+                          OR $clubEvent->evnt_type == 8)
+                        <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-300 bg">
                     @endif
                     @include("partials.event-marker", $clubEvent)
                     &nbsp;&nbsp;
@@ -97,60 +106,46 @@
                 </div>
                 @endif
 
+            
             {{-- show everything for members, but switch the color theme according to event type --}}
-            @else
-                @if($clubEvent->evnt_is_private)
-                    @if ($clubEvent->evnt_type == 1)
-                        <div class="cal-event {{$classString}} calendar-internal-info">
-                    @elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-                        <div class="cal-event {{$classString}} calendar-internal-task">
-                    @elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-                        <div class="cal-event {{$classString}} calendar-internal-marketing">
-                    @elseif (!is_null($clubEvent->section))
-                        <div class="cal-event {{$classString}} calendar-internal-event-{{$clubEvent->section->title}}">
-                    @else
-                        {{-- DEFAULT --}}
-                        <div class="cal-event {{$classString}} dark-grey">
-                    @endif
-                @else
-                    @if     ($clubEvent->evnt_type == 1)
-                        <div class="cal-event {{$classString}} calendar-public-info">
-                    @elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-                        <div class="cal-event {{$classString}} calendar-public-task">
-                    @elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-                        <div class="cal-event {{$classString}} calendar-public-marketing">
-                    @elseif (!is_null($clubEvent->section))
-                        <div class="cal-event {{$classString}} calendar-public-event-{{$clubEvent->section->title}}">
-                    @else
-                        {{-- DEFAULT --}}
-                        <div class="cal-event {{$classString}} dark-grey">
-                    @endif
+            @else       
+                @if     ($clubEvent->evnt_type == 0)
+                    <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-700 bg">
+                @elseif ($clubEvent->evnt_type == 1)
+                    <div class="cal-event {{$classString}} palette-Purple-500 bg">
+                @elseif ($clubEvent->evnt_type == 2 OR $clubEvent->evnt_type == 3)
+                    <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-900 bg">
+                @elseif ($clubEvent->evnt_type == 4 
+                      OR $clubEvent->evnt_type == 5 
+                      OR $clubEvent->evnt_type == 6 
+                      OR $clubEvent->evnt_type == 9)
+                    <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg">
+                @elseif ($clubEvent->evnt_type == 7 
+                      OR $clubEvent->evnt_type == 8)
+                    <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-300 bg">
+                @endif
+
+                @include("partials.event-marker", $clubEvent)
+
+                {{--
+
+                Disabling iCal until fully functional.
+
+                @include("partials.publishStateIndicator")
+
+                --}}
+                    &nbsp;&nbsp;
+                    <a href="{{ URL::route('event.show', $clubEvent->id) }}"
+                       data-toggle="tooltip" 
+                       data-placement="right"
+                       title="{{ trans('mainLang.showDetails')}}">
+                        {{ $clubEvent->evnt_title }}
+                    </a>
+
+                </div>
             @endif
-            @include("partials.event-marker", $clubEvent)
-
-            {{--
-
-            Disabling iCal until fully functional.
-
-            @include("partials.publishStateIndicator")
-
-            --}}
-            &nbsp;&nbsp;
-            <a href="{{ URL::route('event.show', $clubEvent->id) }}"
-               data-toggle="tooltip" 
-               data-placement="right"
-               title="{{ trans('mainLang.showDetails')}}">
-                {{ $clubEvent->evnt_title }}
-            </a>
 
         </div>
 
     @endif
-</div>
-@endif
 @endforeach
-
-
-
-
-

--- a/resources/views/partials/month/monthCell.blade.php
+++ b/resources/views/partials/month/monthCell.blade.php
@@ -27,7 +27,7 @@
         @else
             {{-- meaning Session::has'userId' OR !$survey->is_private == 0--}}
             {{-- so session has a valid user OR the guest can see this survey because it isn't private--}}
-            <div class="cal-event {{$classString}} palette-Grey-500 bg calendar-internal-info">
+            <div class="cal-event {{$classString}} palette-Purple-900 bg">
                 <i class="fa fa-bar-chart-o white-text"></i>
                 &nbsp;&nbsp;
                 {{-- provide a URL to the survey --}}
@@ -84,16 +84,18 @@
                         <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-700 bg">
                     @elseif ($clubEvent->evnt_type == 1)
                         <div class="cal-event {{$classString}} palette-Purple-500 bg">
-                    @elseif ($clubEvent->evnt_type == 2 OR $clubEvent->evnt_type == 3)
+                    @elseif ($clubEvent->evnt_type == 2 
+                          OR $clubEvent->evnt_type == 3)
                         <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-900 bg">
                     @elseif ($clubEvent->evnt_type == 4 
                           OR $clubEvent->evnt_type == 5 
-                          OR $clubEvent->evnt_type == 6 
-                          OR $clubEvent->evnt_type == 9)
+                          OR $clubEvent->evnt_type == 6)
                         <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg">
                     @elseif ($clubEvent->evnt_type == 7 
                           OR $clubEvent->evnt_type == 8)
                         <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-300 bg">
+                    @elseif ($clubEvent->evnt_type == 9)
+                    <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg">
                     @endif
                     @include("partials.event-marker", $clubEvent)
                     &nbsp;&nbsp;
@@ -113,16 +115,18 @@
                     <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-700 bg">
                 @elseif ($clubEvent->evnt_type == 1)
                     <div class="cal-event {{$classString}} palette-Purple-500 bg">
-                @elseif ($clubEvent->evnt_type == 2 OR $clubEvent->evnt_type == 3)
+                @elseif ($clubEvent->evnt_type == 2 
+                      OR $clubEvent->evnt_type == 3)
                     <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-900 bg">
                 @elseif ($clubEvent->evnt_type == 4 
                       OR $clubEvent->evnt_type == 5 
-                      OR $clubEvent->evnt_type == 6 
-                      OR $clubEvent->evnt_type == 9)
+                      OR $clubEvent->evnt_type == 6)
                     <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg">
                 @elseif ($clubEvent->evnt_type == 7 
                       OR $clubEvent->evnt_type == 8)
                     <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-300 bg">
+                @elseif ($clubEvent->evnt_type == 9)
+                    <div class="cal-event {{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg">
                 @endif
 
                 @include("partials.event-marker", $clubEvent)

--- a/resources/views/partials/weekCellFull.blade.php
+++ b/resources/views/partials/weekCellFull.blade.php
@@ -1,42 +1,30 @@
 <div class="panel panel-warning">
-		<?php $classString = "panel panel-heading";?>
-		{{--Check if the event is still going on--}}
-		@if( strtotime($clubEvent->evnt_date_end.' '.$clubEvent->evnt_time_end) < time() )
-			{{-- The event is already over --}}
-			<?php $classString .= " past-event";?>
-		@endif
-
-	@if($clubEvent->evnt_is_private)
-		@if     ($clubEvent->evnt_type == 1)
-			<div class="{{ $classString }} calendar-internal-info white-text">
-		@elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-			<div class="{{ $classString }} calendar-internal-task white-text">
-		@elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-			<div class="{{ $classString }} calendar-internal-marketing white-text">
-		@elseif ($clubEvent->section->id == 1)
-			<div class="{{ $classString }} calendar-internal-event-bc-Club white-text">
-		@elseif ($clubEvent->section->id == 2)
-			<div class="{{ $classString }} calendar-internal-event-bc-Café white-text">
-		@else
-			{{-- DEFAULT --}}
-			<div class="cal-event dark-grey">
-		@endif
-	@else
-		@if     ($clubEvent->evnt_type == 1)
-			<div class="{{ $classString }} calendar-public-info white-text">
-		@elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-			<div class="{{ $classString }} calendar-public-task white-text">
-		@elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-			<div class="{{ $classString }} calendar-public-marketing white-text">
-		@elseif ($clubEvent->section->id == 1)
-			<div class="{{ $classString }} calendar-public-event-bc-Club white-text">
-		@elseif ($clubEvent->section->id == 2)
-			<div class="{{ $classString }} calendar-public-event-bc-Café white-text">
-		@else
-			{{-- DEFAULT --}}
-			<div class="cal-event dark-grey">
-		@endif
+	
+	{{--Check if the event is still going on--}}
+	<?php $classString = "panel panel-heading";?>
+	@if( strtotime($clubEvent->evnt_date_end.' '.$clubEvent->evnt_time_end) < time() )
+		{{-- The event is already over --}}
+		<?php $classString .= " past-event";?>
 	@endif
+
+	{{-- Set panel color --}}
+	@if     ($clubEvent->evnt_type == 0)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-700 bg">
+    @elseif ($clubEvent->evnt_type == 1)
+        <div class="{{$classString}} palette-Purple-500 bg">
+    @elseif ($clubEvent->evnt_type == 2 
+    	  OR $clubEvent->evnt_type == 3)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-900 bg">
+    @elseif ($clubEvent->evnt_type == 4 
+          OR $clubEvent->evnt_type == 5 
+          OR $clubEvent->evnt_type == 6)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg white-text">
+    @elseif ($clubEvent->evnt_type == 7 
+          OR $clubEvent->evnt_type == 8)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-300 bg white-text">
+    @elseif ($clubEvent->evnt_type == 9)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg white-text">
+    @endif
 
 			<h4 class="panel-title">
 				@include("partials.event-marker")

--- a/resources/views/partials/weekCellHidden.blade.php
+++ b/resources/views/partials/weekCellHidden.blade.php
@@ -1,11 +1,10 @@
 <div class="panel panel-default">
-	{{--Check if the event is still going on--}}
-		@if( strtotime($clubEvent->evnt_date_end.' '.$clubEvent->evnt_time_end) < time() )
-			{{-- The event is already over --}}
-				<div class="panel panel-heading past-event">
-		@else
-			<div class="panel panel-heading">
-		@endif
+	{{-- Check if the event is still going on and set panel color --}}
+	@if( strtotime($clubEvent->evnt_date_end.' '.$clubEvent->evnt_time_end) < time() )
+		<div class="panel panel-heading palette-Grey-500 bg white-text past-event">
+	@else
+		<div class="panel panel-heading palette-Grey-500 bg white-text">
+	@endif
 
 		<h4 class="panel-title">
 			<i class="fa fa-eye-slash">&nbsp;&nbsp;</i><span class="name">{{ trans('mainLang.internalEventP') }}</span>
@@ -21,9 +20,9 @@
 		&nbsp;
 		<i class="fa fa-map-marker">&nbsp;</i>{{ $clubEvent->section->title }}
 	</div>
+
 	<div class="panel-body">
-		{{ trans('mainLang.moreDetailsAfterLogInMessage') }} {{-- <br /> --}}
-        {{-- {{ trans('mainLang.moreDetailsAfterLogInMessage2') }}  --}}
+		{{ trans('mainLang.moreDetailsAfterLogInMessage') }} 
 	</div>
 </div>
 	  

--- a/resources/views/partials/weekCellProtected.blade.php
+++ b/resources/views/partials/weekCellProtected.blade.php
@@ -1,41 +1,29 @@
 <div class="panel panel-warning">
+	
+	{{-- Check if the event is still going on --}}
 	<?php $classString = "panel panel-heading";?>
-	{{--Check if the event is still going on--}}
 	@if( strtotime($clubEvent->evnt_date_end.' '.$clubEvent->evnt_time_end) < time() )
-		{{-- The event is already over --}}
 		<?php $classString .= " past-event";?>
 	@endif
-	@if($clubEvent->evnt_is_private)
-		@if     ($clubEvent->evnt_type == 1)
-			<div class="{{ $classString }} calendar-internal-info white-text">
-		@elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-			<div class="{{ $classString }} calendar-internal-task white-text">
-		@elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-			<div class="{{ $classString }} calendar-internal-marketing white-text">
-		@elseif ($clubEvent->section->id == 1)
-			<div class="{{ $classString }} calendar-internal-event-bc-Club white-text">
-		@elseif ($clubEvent->section->id == 2)
-			<div class="{{ $classString }} calendar-internal-event-bc-Café white-text">
-		@else
-			{{-- DEFAULT --}}
-			<div class="cal-event dark-grey">
-		@endif
-	@else
-		@if     ($clubEvent->evnt_type == 1)
-			<div class="{{ $classString }} calendar-public-info white-text">
-		@elseif ($clubEvent->evnt_type == 6 OR $clubEvent->evnt_type == 9)
-			<div class="{{ $classString }} calendar-public-task white-text">
-		@elseif ($clubEvent->evnt_type == 7 OR $clubEvent->evnt_type == 8)
-			<div class="{{ $classString }} calendar-public-marketing white-text">
-		@elseif ($clubEvent->section->id == 1)
-			<div class="{{ $classString }} calendar-public-event-bc-Club white-text">
-		@elseif ($clubEvent->section->id == 2)
-			<div class="{{ $classString }} calendar-public-event-bc-Café white-text">
-		@else
-			{{-- DEFAULT --}}
-			<div class="cal-event dark-grey">
-		@endif
-	@endif
+
+	{{-- Set panel color --}}
+	@if     ($clubEvent->evnt_type == 0)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-700 bg">
+    @elseif ($clubEvent->evnt_type == 1)
+        <div class="{{$classString}} palette-Purple-500 bg">
+    @elseif ($clubEvent->evnt_type == 2 
+    	  OR $clubEvent->evnt_type == 3)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-900 bg">
+    @elseif ($clubEvent->evnt_type == 4 
+          OR $clubEvent->evnt_type == 5 
+          OR $clubEvent->evnt_type == 6)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg white-text">
+    @elseif ($clubEvent->evnt_type == 7 
+          OR $clubEvent->evnt_type == 8)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-300 bg white-text">
+    @elseif ($clubEvent->evnt_type == 9)
+        <div class="{{$classString}} palette-{!! $clubEvent->section->color !!}-500 bg white-text">
+    @endif
 
 			<h4 class="panel-title">
 				@include("partials.event-marker")

--- a/resources/views/partials/weekCellSurvey.blade.php
+++ b/resources/views/partials/weekCellSurvey.blade.php
@@ -1,8 +1,8 @@
-@if(!Session::has('userId') AND $survey->is_private == 0)
-    {{-- no userId means this a guest account, so he gets blocked here--}}
+@if(!Session::has('userId') AND $survey->is_private === 1)
+    {{-- Hide internal surveys from guests --}}
     <div class="panel panel-warning">
 
-        <div class="panel dark-grey white-text" 
+        <div class="panel palette-Grey-500 bg white-text" 
              style="padding: 15px 15px 8px 15px;">
             <h4 class="panel-title">
                 <i class="fa fa-bar-chart-o white-text"></i>
@@ -17,12 +17,11 @@
         </div>
     </div>
 @else 
-    {{-- so session has a valid user OR the guest can see this survey because it isn't private--}}
+    {{-- Show everything to memebers --}}
     <div class="panel panel-warning">
 
-        <div class="panel panel-heading calendar-public-info white-text">
+        <div class="panel panel-heading palette-Purple-900 bg white-text">
             <h4 class="panel-title">
-                {{-- provide a URL to the survey --}}
                 <a href="{{ URL::route('survey.show', $survey->id) }}">
                     <i class="fa fa-bar-chart-o white-text"></i>
                     &nbsp;

--- a/resources/views/sectionView.blade.php
+++ b/resources/views/sectionView.blade.php
@@ -41,14 +41,32 @@
 							   array('id'=>'title')) !!}
 						</td>
 					</tr>
-					<tr>
+					<tr class="form-group">
 						<td width="20%" class="left-padding-16">
-							<i>{{ trans('mainLang.color') }}:</i>
+							<label for="color">
+								<i>{{ trans('mainLang.color') }}:</i>
+							</label>
 						</td>
 						<td>
-							{!! Form::input('text','color', 
-							   $current_section->color, 
-							   array('id'=>'color')) !!}
+							<span class="col-md-12 col-sm-12 col-xs-12 no-padding">
+								{!! Form::text('color', $current_section->color, array('id'=>'color', 'readonly') ) !!}
+							 	<a class="btn-small btn-primary dropdown-toggle" 
+							 	   data-toggle="dropdown" 
+							 	   href="javascript:void(0);">
+							        <span class="caret"></span>
+							    </a>
+							    <ul class="dropdown-menu">
+								    @foreach(config('color.colors') as $color)
+								        <li> 
+								        	<a href="javascript:void(0);" 
+								        	   class="palette-{{$color}}-500-Primary bg"
+								        	   onClick="document.getElementById('color').value='{{$color}}'">
+								        		{{ $color }}
+								        	</a>
+								        </li>
+									@endforeach
+							    </ul>  	
+						    </span>
 						</td>
 					</tr>
 					<tr>

--- a/resources/views/sectionView.blade.php
+++ b/resources/views/sectionView.blade.php
@@ -49,7 +49,7 @@
 						</td>
 						<td>
 							<span class="col-md-12 col-sm-12 col-xs-12 no-padding">
-								{!! Form::text('color', $current_section->color, array('id'=>'color', 'readonly') ) !!}
+								{!! Form::text('color', $current_section->color, array('id'=>'color', 'readonly', 'class'=>'palette-'.$current_section->color.'-500-Primary bg') ) !!}
 							 	<a class="btn-small btn-primary dropdown-toggle" 
 							 	   data-toggle="dropdown" 
 							 	   href="javascript:void(0);">


### PR DESCRIPTION
Let's try again ;)

Event colors are now pulled out of palette.css using values saved in the Section model.

For the record: I'm working in parallel on a big month view redesign, and basically rewrite it from scratch, so the aim of these changes are _only_ to introduce correct color handling. No further refactoring was intended (or should be done at this point) - it will be done later in a separate PR.

Discussion:
[ILSCeV/Lara] New comment by P1tt187 on pull request #250: Feature/generic section colors
after switching to the branch all events are not styled until i choose a color in the section menu
could you please add a migration with default colors for each section?


[10:43] 
[ILSCeV/Lara] New comment by 4D44H on pull request #250: Feature/generic section colors
It's rather a seeds problem - the seeder has not added these values. in prod they are already set, afaik.


[10:46] 
[Lara:feature/generic-section-colors] 1 new commit by 4D44H:
`3fa9934` Add color to seeds for section preferences - 4D44H


[10:46] 
[ILSCeV/Lara] New comment by 4D44H on pull request #250: Feature/generic section colors
That should do it, try `php artisan migrate:refresh --seed`


[10:48] 
[ILSCeV/Lara] New comment by P1tt187 on pull request #250: Feature/generic section colors
I testet with the dump, so this is missing for those data


[10:50] 
[ILSCeV/Lara] New comment by 4D44H on pull request #250: Feature/generic section colors
Hm, okay... I thought we did that already. I'll add it later then, together with other section preferences like DV times etc.