### PR TITLE
Abort auto scrolling in month view

### DIFF
--- a/resources/assets/ts/vedst-scripts.ts
+++ b/resources/assets/ts/vedst-scripts.ts
@@ -263,6 +263,10 @@ function decodeEntities(encodedString) {
 // Month view //
 ////////////////
 
+//This event listener is enabled while the scrolling to today anymation is running. If the user touches the screen, the animation is stopped.
+function stopScrollOnTouch(){
+    $('html, body').stop();
+}
 
 // Scroll to current date/event if in mobile view in current month
 $(document).ready(function()
@@ -272,9 +276,17 @@ $(document).ready(function()
     {
         if ($(window).width() < 978)
         {
-            $('html, body').animate({ scrollTop: $(".scroll-marker").offset().top -80 }, 1000);
-        };
-    };
+            //Add event listener to stop scrolling when the user touches the screen.
+            document.addEventListener("touchstart", stopScrollOnTouch, false);
+
+            $('html, body').animate({ scrollTop: $(".scroll-marker").offset().top -80 }, {
+                duration: 1000,
+                always:()=>{
+                    //Scroll completed or Aborted, remove the touch listener
+                    document.removeEventListener("touchstart", stopScrollOnTouch);
+                }});
+        }
+    }
 });
 
 


### PR DESCRIPTION
When a User touches the screen, abort the scrolling to today in the mobile month view.