### PR TITLE
Fix/user created from person

### DIFF
--- a/app/Console/Commands/LDAPsync.php
+++ b/app/Console/Commands/LDAPsync.php
@@ -83,7 +83,11 @@ class LDAPsync extends Command
 
 // STARTING THE UPDATE
         $persons->each(function (Person $person) use ($bar, $allowedSection, $ldapConn) {
-            $user = $person->user();
+            $user = $person->user;
+
+            if (!$user) {
+                $user = User::createFromPerson($person);
+            }
             $bar->advance();
             // skip ldap override
             if ($person->prsn_ldap_id == '9999') {

--- a/app/Console/Commands/SyncBDclub.php
+++ b/app/Console/Commands/SyncBDclub.php
@@ -8,6 +8,7 @@ use ICal\ICal;
 use Illuminate\Console\Command;
 use Lara\Club;
 use Lara\ClubEvent;
+use Lara\Logging;
 use Lara\Person;
 use Lara\Schedule;
 use Lara\Section;
@@ -123,6 +124,7 @@ class SyncBDclub extends Command
                 if (is_null($clubEvent)) {
                     $this->info('Create new event for ' . $icevt->summary);
                     $clubEvent = new ClubEvent();
+
                 } else {
                     $this->info('update event ' . $icevt->summary);
                 }
@@ -152,6 +154,7 @@ class SyncBDclub extends Command
                 $schedule = $clubEvent->schedule;
                 if (is_null($schedule)) {
                     $schedule = new Schedule();
+                    Logging::scheduleCreated($schedule);
                 }
                 $schedule->evnt_id = $clubEvent->id;
                 $schedule->schdl_title = $clubEvent->evnt_title;

--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -598,11 +598,6 @@ class ClubEventController extends Controller
             $event->evnt_is_published = 0;
         }
 
-        // Filter
-        $filter = collect(Input::get("filter"))->values()->toArray();
-
-        $event->save();
-        $event->showToSection()->sync($filter);
 
         // Logging
 
@@ -633,6 +628,11 @@ class ClubEventController extends Controller
             }
 
         }
+        // Filter
+        $filter = collect(Input::get("filter"))->values()->toArray();
+
+        $event->save();
+        $event->showToSection()->sync($filter);
         return $event;
     }
 

--- a/app/Http/Controllers/IcalController.php
+++ b/app/Http/Controllers/IcalController.php
@@ -223,8 +223,11 @@ class IcalController extends Controller
             $person = Person::where('prsn_uid', '=', $prsn_uid)->first();
 
             if(isset($person)) {
-                $user = $person->user();
-                $userSettings = $user->settings;
+                $user = $person->user;
+
+                if (isset($user)) {
+                    $userSettings = $user->settings;
+                }
 
                 if (isset($userSettings)) {
                     Session::put('applocale', $userSettings->language);

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -451,8 +451,7 @@ class LoginController extends Controller
     }
 
     /**
-     * @param $info
-     * @param $userGroup
+     * @param $user User
      */
     protected function logSuccessfulAuthentication($user)
     {
@@ -461,7 +460,8 @@ class LoginController extends Controller
         $nickName = $user->name;
         $givenName = $user->givenname;
         $displayName = !empty($nickName) ? $nickName : $givenName;
-        $roles = $user->roles->map(function($role) {
+        $roles=$user->roles->unique();
+        $rolesString = $roles->map(function($role) {
             return $role->section->title  . ": " . $role->name;
         })->implode(', ');
 
@@ -472,7 +472,7 @@ class LoginController extends Controller
             ', "' .
             $displayName .
             '", ' .
-            $roles .
+            $rolesString .
             ') just logged in.');
     }
 

--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -336,10 +336,7 @@ class ShiftController extends Controller
         // If no id is set, create a new Model
         $shift = self::createShiftsFromEditSchedule($id,$title,$type,$start,$end,$weight,$position);
         $shift->schedule_id = $schedule->id;
-        if (!$isNewEvent) {
-            $shift->save();
-            Logging::shiftCreated($shift);
-        }
+
         $shift->save();
     }
 
@@ -409,6 +406,9 @@ class ShiftController extends Controller
             if ($shift->isDirty('end')) {
                 Logging::shiftEndChanged($shift);
             }
+        }
+        else {
+            Logging::shiftCreated($shift);
         }
         $shift->save();
         return $shift;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -141,6 +141,11 @@ class UserController extends Controller
         }
 
         $user->fill($request->all())->save();
+
+        $person = $user->person;
+        $person->prsn_status = $user->status;
+        $person->save();
+
         Utilities::success(trans('mainLang.update'));
         return Redirect::back();
     }
@@ -221,7 +226,7 @@ class UserController extends Controller
         $user->fill($data);
 
         $person = $user->person;
-        $person->status = $user->status;
+        $person->prsn_status = $user->status;
         $person->save();
 
         $changedSection = $user->isDirty('section_id');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -219,6 +219,11 @@ class UserController extends Controller
         $unassignedRoles = Role::query()->whereIn('id', $unassignedRoleIds)->get();
 
         $user->fill($data);
+
+        $person = $user->person;
+        $person->status = $user->status;
+        $person->save();
+
         $changedSection = $user->isDirty('section_id');
         $user->save();
 

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -97,16 +97,31 @@ class Logging
     public static function newScheduleRevision($schedule, $action, $old = "", $new = "")
     {
         $user = Auth::user();
-        $person = $user->person;
+
+        if ($user) {
+            $person = $user->person;
+            return [
+                "entry id" => is_null($schedule) ? "" : $schedule->id,
+                "job type" => "",
+                "action" => $action,
+                "old value" => $old,
+                "new value" => $new,
+                "user id" => $person->prsn_ldap_id != NULL ? $person->prsn_ldap_id : "",
+                "user name" => $person->prsn_ldap_id != NULL ? $user->name . ' (' . $person->club->clb_title . ')' : "Gast",
+                "from ip" => Request::getClientIp(),
+                "timestamp" => (new DateTime)->format('d.m.Y H:i:s')
+            ];
+        }
+        // If no one is logged in, the event is created from an import or other automated tasks => Use Lara as creator
         return [
             "entry id" => is_null($schedule) ? "" : $schedule->id,
             "job type" => "",
             "action" => $action,
             "old value" => $old,
             "new value" => $new,
-            "user id" => $person->prsn_ldap_id != NULL ? $person->prsn_ldap_id : "",
-            "user name" => $person->prsn_ldap_id != NULL ? $user->name . ' (' . $person->club->clb_title . ')' : "Gast",
-            "from ip" => Request::getClientIp(),
+            "user id" => "",
+            "user name" => "Lara",
+            "from ip" => "",
             "timestamp" => (new DateTime)->format('d.m.Y H:i:s')
         ];
     }

--- a/app/Person.php
+++ b/app/Person.php
@@ -82,12 +82,11 @@ class Person extends Model
     }
 
     /**
-     * @return \Lara\User
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne|User
      */
     public function user()
     {
-        $userRelationship = $this->hasOne(User::class);
-        return $userRelationship->exists() ? $userRelationship->first() : User::createFromPerson($this);
+        return $this->hasOne(User::class);
     }
 
     /**
@@ -109,7 +108,7 @@ class Person extends Model
 
     public function fullName()
     {
-        $user = $this->user();
+        $user = $this->user;
 
         if ($user && Gate::allows('accessInformation', $user)) {
             return $user->fullName();

--- a/app/User.php
+++ b/app/User.php
@@ -19,7 +19,7 @@ use Lara\Status;
  * @property string status
  * @property string givenname
  * @property string lastname
- * @property \Illuminate\Database\Eloquent\Relations\belongsToMany|Role $roles
+ * @property \Illuminate\Database\Eloquent\Relations\belongsToMany|Role roles
  */
 class User extends Authenticatable
 {

--- a/app/User.php
+++ b/app/User.php
@@ -108,6 +108,10 @@ class User extends Authenticatable
 
     public static function createFromPerson(Person $person)
     {
+        if ($person->user) {
+            return $person->user;
+        }
+
         if (!$person->club) {
             return NULL;
         }
@@ -128,6 +132,8 @@ class User extends Authenticatable
             $user, $person->club->section(),
             RoleUtility::PRIVILEGE_MEMBER
         );
+
+        $person->user = $user;
 
         return $user;
     }

--- a/database/migrations/2018_03_27_154114_add_creator_id_to_clubevent.php
+++ b/database/migrations/2018_03_27_154114_add_creator_id_to_clubevent.php
@@ -39,7 +39,7 @@ class AddCreatorIdToClubevent extends Migration
                 if (is_null($person)) {
                     return;
                 }
-                $user = $person->user();
+                $user = $person->user;
 
                 $event->creator_id = $user->id;
             });

--- a/database/migrations/2018_04_01_163227_move_setting_to_users.php
+++ b/database/migrations/2018_04_01_163227_move_setting_to_users.php
@@ -25,7 +25,7 @@ class MoveSettingToUsers extends Migration
             if (!$person) {
                 return;
             }
-            $settings->user_id = $person->user()->id;
+            $settings->user_id = $person->user->id;
             $settings->save();
         });
 

--- a/resources/views/partials/statistics/leaderboardsOfClub.blade.php
+++ b/resources/views/partials/statistics/leaderboardsOfClub.blade.php
@@ -13,9 +13,9 @@
         {{-- Only show Top 10 Shifts --}}
         @foreach($infos->sortByDesc('inOwnClub')->take(10) as $info)
             @php
-                $user = $info->user->user();
+                $user = $info->user->user;
             @endphp
-            <tr class=" {{Auth::user()->id === $info->user->user()->id ? 'my-shift' : ''}}">
+            <tr class=" {{Auth::user()->id === $info->user->user->id ? 'my-shift' : ''}}">
                 <td>
                     @include('partials.personStatusMarker', ['status' => $user->status, 'section' => $user->section])
                     <span data-toggle="tooltip" data-placement="top" title="{{ $user->fullName() }}" >

--- a/resources/views/partials/statisticsMembers.blade.php
+++ b/resources/views/partials/statisticsMembers.blade.php
@@ -37,7 +37,7 @@
                     <tbody>
                         @foreach($clubInfo as $info)
                             @php
-                                $user = $info->user->user();
+                                $user = $info->user->user;
                             @endphp
                             <tr class="{{Auth::user()->id === $user->id? 'my-shift' : ''}}">
                                 <td>

--- a/resources/views/privacyPolicy.blade.php
+++ b/resources/views/privacyPolicy.blade.php
@@ -10,18 +10,20 @@
     <br class="visible-sm">
 
 
-    @if(Auth::user()->privacy_accepted == 0)
-    <div class="panel panel-danger">
-        <div class="panel-heading">
-            <h3 class="panel-title">{{ trans("mainLang.waitOneSecond") }}</h3>
-        </div>
+    @auth
+        @if(Auth::user()->privacy_accepted == 0)
+        <div class="panel panel-danger">
+            <div class="panel-heading">
+                <h3 class="panel-title">{{ trans("mainLang.waitOneSecond") }}</h3>
+            </div>
 
-        <div class="panel-body">
-            <strong>{{ trans('mainLang.agreeWithPrivacy') }}</strong>
+            <div class="panel-body">
+                <strong>{{ trans('mainLang.agreeWithPrivacy') }}</strong>
+            </div>
         </div>
-    </div>
-    <br>
-    @endif
+        <br>
+        @endif
+    @endauth
 
     <div class="panel panel-primary">
         <div class="panel-heading">
@@ -743,15 +745,17 @@
                     </p>
                 </div>
             </div>
-            @if(Auth::user()->privacy_accepted == 0)
-                <div class="panel-footer">
-                <hr>
-                <form method="post" action="{{url('userAgreesPrivacy')}}" enctype="multipart/form-data">
-                    {{ csrf_field() }}
-                    <button type="submit" class="btn btn-success">{{ trans("mainLang.privacyAgree") }}</button>
-                </form>
-                </div>
-            @endif
+            @auth
+                @if(Auth::user()->privacy_accepted == 0)
+                    <div class="panel-footer">
+                    <hr>
+                    <form method="post" action="{{url('userAgreesPrivacy')}}" enctype="multipart/form-data">
+                        {{ csrf_field() }}
+                        <button type="submit" class="btn btn-success">{{ trans("mainLang.privacyAgree") }}</button>
+                    </form>
+                    </div>
+                @endif
+            @endauth
         </div>
     </div>
 @stop


### PR DESCRIPTION
On production there is a bug: A user will be created once an event with a Person that is not related to a user has a shift in this event. 

This bug was caused by `$person->fullName()`, which in turn calls `$person->user` which created a User object. This is now fixed and the relevant lines now will either create a User or return a default value if no user is to be created.