### PR TITLE
Add log message for synced bd-Events

### DIFF
--- a/app/Console/Commands/SyncBDclub.php
+++ b/app/Console/Commands/SyncBDclub.php
@@ -8,6 +8,7 @@ use ICal\ICal;
 use Illuminate\Console\Command;
 use Lara\Club;
 use Lara\ClubEvent;
+use Lara\Logging;
 use Lara\Person;
 use Lara\Schedule;
 use Lara\Section;
@@ -123,6 +124,7 @@ class SyncBDclub extends Command
                 if (is_null($clubEvent)) {
                     $this->info('Create new event for ' . $icevt->summary);
                     $clubEvent = new ClubEvent();
+
                 } else {
                     $this->info('update event ' . $icevt->summary);
                 }
@@ -152,6 +154,7 @@ class SyncBDclub extends Command
                 $schedule = $clubEvent->schedule;
                 if (is_null($schedule)) {
                     $schedule = new Schedule();
+                    Logging::scheduleCreated($schedule);
                 }
                 $schedule->evnt_id = $clubEvent->id;
                 $schedule->schdl_title = $clubEvent->evnt_title;

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -97,16 +97,31 @@ class Logging
     public static function newScheduleRevision($schedule, $action, $old = "", $new = "")
     {
         $user = Auth::user();
-        $person = $user->person;
+
+        if ($user) {
+            $person = $user->person;
+            return [
+                "entry id" => is_null($schedule) ? "" : $schedule->id,
+                "job type" => "",
+                "action" => $action,
+                "old value" => $old,
+                "new value" => $new,
+                "user id" => $person->prsn_ldap_id != NULL ? $person->prsn_ldap_id : "",
+                "user name" => $person->prsn_ldap_id != NULL ? $user->name . ' (' . $person->club->clb_title . ')' : "Gast",
+                "from ip" => Request::getClientIp(),
+                "timestamp" => (new DateTime)->format('d.m.Y H:i:s')
+            ];
+        }
+        // If no one is logged in, the event is created from an import or other automated tasks => Use Lara as creator
         return [
             "entry id" => is_null($schedule) ? "" : $schedule->id,
             "job type" => "",
             "action" => $action,
             "old value" => $old,
             "new value" => $new,
-            "user id" => $person->prsn_ldap_id != NULL ? $person->prsn_ldap_id : "",
-            "user name" => $person->prsn_ldap_id != NULL ? $user->name . ' (' . $person->club->clb_title . ')' : "Gast",
-            "from ip" => Request::getClientIp(),
+            "user id" => "",
+            "user name" => "Lara",
+            "from ip" => "",
             "timestamp" => (new DateTime)->format('d.m.Y H:i:s')
         ];
     }


### PR DESCRIPTION
We will now log the timestamp of newly synced bd-Events.
Because this command will be run by the server, no user is logged in. To
prevent `Auth::user()` failure in the logging, we set the logged name to
'Lara'.

Please discuss if this is appropriate, other names could be 'System' or
'BD-Sync'.

Also open for discussion: Should we log more than just the creation date?