### PR TITLE
Fix logging in events (details + shifts)

### DIFF
--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -598,11 +598,6 @@ class ClubEventController extends Controller
             $event->evnt_is_published = 0;
         }
 
-        // Filter
-        $filter = collect(Input::get("filter"))->values()->toArray();
-
-        $event->save();
-        $event->showToSection()->sync($filter);
 
         // Logging
 
@@ -633,6 +628,11 @@ class ClubEventController extends Controller
             }
 
         }
+        // Filter
+        $filter = collect(Input::get("filter"))->values()->toArray();
+
+        $event->save();
+        $event->showToSection()->sync($filter);
         return $event;
     }
 

--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -336,10 +336,7 @@ class ShiftController extends Controller
         // If no id is set, create a new Model
         $shift = self::createShiftsFromEditSchedule($id,$title,$type,$start,$end,$weight,$position);
         $shift->schedule_id = $schedule->id;
-        if (!$isNewEvent) {
-            $shift->save();
-            Logging::shiftCreated($shift);
-        }
+
         $shift->save();
     }
 
@@ -409,6 +406,9 @@ class ShiftController extends Controller
             if ($shift->isDirty('end')) {
                 Logging::shiftEndChanged($shift);
             }
+        }
+        else {
+            Logging::shiftCreated($shift);
         }
         $shift->save();
         return $shift;


### PR DESCRIPTION
Since logging was implemented something broke the correct triggers for
logs. This PR aims to fix this.

First of, if one calls `$event->save()` before the `$event->isDirty(...)`
checks are called, the event is saved to the DB, therefore no attribute
is dirty. This caused the missing logs for event infos.

Line 60 in the ShiftController caused shifts to always be logged as
newly created. This is now fixed (see ~line 70 in the same file).