### PR TITLE
Add darker shade of grey to color picker

### DIFF
--- a/config/color.php
+++ b/config/color.php
@@ -15,7 +15,7 @@ return [
 	"colors" => [
 		"Red", 
 		"Pink", 
-		// "Purple",      // RESERVED for Info events and Surveys
+		// "Purple",      	// RESERVED for Info events and Surveys
 		"Deep-Purple",
 		"Indigo", 
 		"Blue", 
@@ -31,7 +31,7 @@ return [
 		"Deep-Orange", 
 		// "Brown",          // Doesn't have shades: A100, A200, A400, A700
 		// "Grey",           // Doesn't have shades: A100, A200, A400, A700      // RESERVED for Hidden events
-		// "Blue-Grey"       // Doesn't have shades: A100, A200, A400, A700      // RESERVED for Hidden surveys
+		"Blue-Grey"       	 // Doesn't have shades: A100, A200, A400, A700      
 	],
 
     // Note that not all color have all the shades


### PR DESCRIPTION
Added "Blue-Grey" aka Anthrazit from GOogle Material Design Panel to the list of choices available.

Warning: this color does not support A-Shades (A100, A200, A400, A700). We do not use them now, but this might be an issue later on.

![image](https://user-images.githubusercontent.com/11014468/40878728-6b549ec0-6695-11e8-823f-4d0ad1574df6.png)

