### PR TITLE
Fix syncing of BD-Events

### DIFF
--- a/app/ClubEvent.php
+++ b/app/ClubEvent.php
@@ -77,6 +77,7 @@ class ClubEvent extends Model
         'event_url',
         'template_id',
         'creator_id',
+        'was_manually_edited',
     ];
 
     /**

--- a/app/Console/Commands/SyncBDclub.php
+++ b/app/Console/Commands/SyncBDclub.php
@@ -121,10 +121,14 @@ class SyncBDclub extends Command
 
                 /* @var $clubEvent ClubEvent */
                 $clubEvent = ClubEvent::where('external_id', '=', $icevt->uid)->first();
+
                 if (is_null($clubEvent)) {
                     $this->info('Create new event for ' . $icevt->summary);
                     $clubEvent = new ClubEvent();
 
+                } else if ($clubEvent->was_manually_edited){
+                    $this->info('Skipping Event' . $icevt->summary . '. It was manually edited.');
+                    continue;
                 } else {
                     $this->info('update event ' . $icevt->summary);
                 }

--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -438,6 +438,9 @@ class ClubEventController extends Controller
                  . ') edited event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
 
 
+        if ($event->isDirty() || $schedule->isDirty()) {
+            $event->was_manually_edited = true;
+        }
         // save all data in the database
         $event->save();
         $schedule->save();

--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -437,10 +437,6 @@ class ClubEventController extends Controller
         Log::info('Event edited: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
                  . ') edited event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
 
-
-        if ($event->isDirty() || $schedule->isDirty()) {
-            $event->was_manually_edited = true;
-        }
         // save all data in the database
         $event->save();
         $schedule->save();

--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -100,22 +100,13 @@ class ScheduleController extends Controller
         }
 
         // format: password; validate on filled value
-        if (Input::get('password') == "delete"
-        && Input::get('passwordDouble') == "delete")
-        {
+        if (Input::get('password') == "delete" && Input::get('passwordDouble') == "delete") {
             $schedule->schdl_password = '';
         }
         elseif (!empty(Input::get('password'))
             && !empty(Input::get('passwordDouble'))
-            && Input::get('password') == Input::get('passwordDouble'))
-        {
+            && Input::get('password') == Input::get('passwordDouble')) {
             $schedule->schdl_password = Hash::make(Input::get('password'));
-        }
-
-        if ($schedule->exists) {
-            if ($schedule->isDirty('schdl_time_preparation_start')) {
-                Logging::preparationTimeChanged($schedule);
-            }
         }
 
         return $schedule;

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -38,14 +38,13 @@ class Logging
         array_push($revisions, $newRevision);
 
         $schedule->entry_revisions = json_encode($revisions);
-
-        $schedule->save();
     }
 
     public static function logEventRevision(ClubEvent $event, $action, $old = "", $new = "")
     {
         if ($event->schedule) {
             self::logScheduleRevision($event->schedule, $action, $old, $new);
+            $event->schedule->save();
         }
     }
 

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -24,8 +24,6 @@ class Logging
         array_push($revisions, $newRevision);
 
         $schedule->entry_revisions = json_encode($revisions);
-
-        $schedule->save();
     }
 
     public static function logScheduleRevision(Schedule $schedule, $action, $old = "" , $new = "")
@@ -38,8 +36,6 @@ class Logging
         array_push($revisions, $newRevision);
 
         $schedule->entry_revisions = json_encode($revisions);
-
-        $schedule->save();
     }
 
     public static function logEventRevision(ClubEvent $event, $action, $old = "", $new = "")

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -44,7 +44,9 @@ class Logging
 
     public static function logEventRevision(ClubEvent $event, $action, $old = "", $new = "")
     {
-        self::logScheduleRevision($event->schedule, $action, $old, $new);
+        if ($event->schedule) {
+            self::logScheduleRevision($event->schedule, $action, $old, $new);
+        }
     }
 
     public static function ensureShiftHasRevisions(Shift $shift)

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -38,6 +38,8 @@ class Logging
         array_push($revisions, $newRevision);
 
         $schedule->entry_revisions = json_encode($revisions);
+
+        $schedule->save();
     }
 
     public static function logEventRevision(ClubEvent $event, $action, $old = "", $new = "")

--- a/app/Logging.php
+++ b/app/Logging.php
@@ -24,6 +24,8 @@ class Logging
         array_push($revisions, $newRevision);
 
         $schedule->entry_revisions = json_encode($revisions);
+
+        $schedule->save();
     }
 
     public static function logScheduleRevision(Schedule $schedule, $action, $old = "" , $new = "")

--- a/app/Observers/ClubEventObserver.php
+++ b/app/Observers/ClubEventObserver.php
@@ -3,6 +3,8 @@
 namespace Lara\Observers;
 
 use Auth;
+use Log;
+
 use Lara\ClubEvent;
 
 class ClubEventObserver
@@ -27,4 +29,52 @@ class ClubEventObserver
         }
     }
 
+    public function created(ClubEvent $event) 
+    {
+        $user = Auth::user();
+        Log::info('Event created: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
+                 . ') created event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+    }
+
+    public function updating(ClubEvent $event) 
+    {
+        if ($event->isDirty('evnt_time_start')) {
+            Logging::eventStartChanged($event);
+        }
+
+        if ($event->isDirty('evnt_title')) {
+            Logging::eventTitleChanged($event);
+        }
+
+        if ($event->isDirty('evnt_subtitle')) {
+            Logging::eventSubtitleChanged($event);
+        }
+
+        if ($event->isDirty('evnt_time_end')) {
+            Logging::eventEndChanged($event);
+        }
+
+        if ($event->isDirty('evnt_public_info')) {
+            Logging::logEventRevision($event, "revisions.eventPublicInfoChanged");
+        }
+
+        if ($event->isDirty('evnt_private_details')) {
+            Logging::logEventRevision($event, "revisions.eventPrivateDetailsChanged");
+        }
+    }
+
+
+    public function updated(ClubEvent $event) 
+    {
+        $user = Auth::user();
+        Log::info('Event edited: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
+                 . ') edited event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+    }
+
+    public function deleted(ClubEvent $event) 
+    {
+        $user = Auth::user();
+        Log::info('Event deleted: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
+                 . ') deleted event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+    }
 }

--- a/app/Observers/ClubEventObserver.php
+++ b/app/Observers/ClubEventObserver.php
@@ -6,6 +6,7 @@ use Auth;
 use Log;
 
 use Lara\ClubEvent;
+use Lara\Logging;
 
 class ClubEventObserver
 {

--- a/app/Observers/ClubEventObserver.php
+++ b/app/Observers/ClubEventObserver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Lara\Observers;
+
+use Auth;
+use Lara\ClubEvent;
+
+class ClubEventObserver
+{
+    /**
+     * Listen to the ClubEvent saving event.
+     * Could also put this into the 'updating' method.
+     * This way, manually created events will also receive the 
+     * 'was_manually_edited' flag, which seems consistent.
+     *
+     * @param  Lara\ClubEvent  $event
+     * @return void
+     */
+    public function saving(ClubEvent $event)
+    {
+        $user = Auth::user();
+
+        $isDirty = $event->isDirty();
+
+        if ($user && $isDirty) {
+            $event->was_manually_edited = true;
+        }
+    }
+
+}

--- a/app/Observers/ClubEventObserver.php
+++ b/app/Observers/ClubEventObserver.php
@@ -33,8 +33,13 @@ class ClubEventObserver
     public function created(ClubEvent $event) 
     {
         $user = Auth::user();
-        Log::info('Event created: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
-                 . ') created event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+
+        if ($user) {
+            Log::info('Event created: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
+                . ') created event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        } else {
+            Log::info('Event created by sync: ' . '"' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        }
     }
 
     public function updating(ClubEvent $event) 
@@ -68,14 +73,25 @@ class ClubEventObserver
     public function updated(ClubEvent $event) 
     {
         $user = Auth::user();
-        Log::info('Event edited: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
-                 . ') edited event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        
+        if ($user) {
+            Log::info('Event edited: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
+                . ') edited event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        } else {
+            Log::info('Event edited by sync: "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        }
+
     }
 
     public function deleted(ClubEvent $event) 
     {
         $user = Auth::user();
-        Log::info('Event deleted: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
-                 . ') deleted event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        if ($user) {
+            Log::info('Event deleted: ' . $user->name . ' (' . $user->person->prsn_ldap_id . ', '
+                . ') deleted event "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        } else {
+            Log::info('Event deleted by sync: "' . $event->evnt_title . '" (eventID: ' . $event->id . ') on ' . $event->evnt_date_start . '.');
+        }
+
     }
 }

--- a/app/Observers/ScheduleObserver.php
+++ b/app/Observers/ScheduleObserver.php
@@ -38,7 +38,6 @@ class ScheduleObserver
 
         if ($dirty->has('schdl_time_preparation_start')) {
             Logging::preparationTimeChanged($schedule);
-
         }
 
         if ($user && $dirty->isNotEmpty()) {

--- a/app/Observers/ScheduleObserver.php
+++ b/app/Observers/ScheduleObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Lara\Observers;
+
+use Lara\Schedule;
+use Lara\Logging;
+
+use Auth;
+
+class ScheduleObserver
+{
+    /**
+     * Listen to the Schedule saving event
+     *
+     * @param  Lara\Schedule  $schedule
+     * @return void
+     */
+    public function saving(Schedule $schedule)
+    {
+        $user = Auth::user();
+
+        $isDirty = $schedule->isDirty();
+
+        if ($user && $isDirty) {
+            $event = $schedule->event;
+
+            $event->was_manually_edited = true;
+
+            $event->save();
+        }
+    }
+
+}

--- a/app/Observers/ScheduleObserver.php
+++ b/app/Observers/ScheduleObserver.php
@@ -29,10 +29,10 @@ class ScheduleObserver
 
     public function updating(Schedule $schedule) 
     {
+        $dirty = collect($schedule->getDirty());
         // entry-revisons should not count to modifying the event
         // they could also be caused by changing shifts
-        $dirty = collect($schedule->getDirty())
-            ->pull('entry_revisions');
+        $dirty->pull('entry_revisions');
 
         $user = Auth::user();
 

--- a/app/Observers/ScheduleObserver.php
+++ b/app/Observers/ScheduleObserver.php
@@ -17,17 +17,37 @@ class ScheduleObserver
      */
     public function saving(Schedule $schedule)
     {
+
+
+    }
+
+
+    public function created(Schedule $schedule) 
+    {
+        Logging::scheduleCreated($schedule);
+    }
+
+    public function updating(Schedule $schedule) 
+    {
+        // entry-revisons should not count to modifying the event
+        // they could also be caused by changing shifts
+        $dirty = collect($schedule->getDirty())
+            ->pull('entry_revisions');
+
         $user = Auth::user();
 
-        $isDirty = $schedule->isDirty();
+        if ($dirty->has('schdl_time_preparation_start')) {
+            Logging::preparationTimeChanged($schedule);
 
-        if ($user && $isDirty) {
+        }
+
+        if ($user && $dirty->isNotEmpty()) {
             $event = $schedule->event;
 
             $event->was_manually_edited = true;
 
             $event->save();
         }
-    }
 
+    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,12 +4,19 @@ namespace Lara\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+
 use Lara\Policies\RolePolicy;
 use Lara\Policies\UserPolicy;
+
 use Lara\Role;
 use Lara\Section;
 use Lara\User;
+use Lara\ClubEvent;
+use Lara\Schedule;
 use Lara\utilities\RoleUtility;
+
+use Lara\Observers\ScheduleObserver;
+use Lara\Observers\ClubEventObserver;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -53,6 +60,7 @@ class AuthServiceProvider extends ServiceProvider
             return true;
         });
 
-
+        ClubEvent::observe(ClubEventObserver::class);
+        Schedule::observe(ScheduleObserver::class);
     }
 }

--- a/database/migrations/2018_07_14_124821_add_event_was_manually_edited.php
+++ b/database/migrations/2018_07_14_124821_add_event_was_manually_edited.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEventWasManuallyEdited extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('club_events', function (Blueprint $table) {
+            $table->boolean('was_manually_edited')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('club_events', function (Blueprint $table) {
+            $table->dropColumn('was_manually_edited');
+        });
+    }
+}


### PR DESCRIPTION
We add a new property `was_manually_edited` to the ClubEvents. If an event (or its schedule) was modified, this property is set to true. Default is false.

This required the `$schedule->save()` calls in Logging to be removed (we have to check `$schedule->isDirty()` for changes). This should not pose any problems, as callers of the logging methods should also call `$schedule->save()`, except for Shift updates (where we save the schedule).

A better model for this would be to use [Observers](https://laravel.com/docs/5.6/eloquent#observers). 
This could also be used to slim down the Controllers (e.g. take the logging into the observers and call before saving a model instance). 