### PR TITLE
 The "Current week" in the month view gets highlighted without checking the year

### DIFF
--- a/resources/views/monthView.blade.php
+++ b/resources/views/monthView.blade.php
@@ -71,7 +71,7 @@
         @foreach($mondays as $weekStart)
             {{-- Add one week to the week start to get the next monday --}}
             <?php $weekEnd = new DateTime($weekStart->format('Y-m-d')); $weekEnd->modify('+1 week') ?>
-            @if ($weekStart->format('W') === date('W'))
+            @if ($weekStart->format('W/o') === date('W/o'))
                 {{-- Current week --}}
                 <div class="calendarRow clearfix group WeekMarkerRow" >
                     <div class="calendarWeek WeekMarker">

--- a/resources/views/partials/month/day.blade.php
+++ b/resources/views/partials/month/day.blade.php
@@ -1,7 +1,7 @@
 @if ($weekDay->format('Y-m-d') === date('Y-m-d'))
     {{-- The actual date of today marked in dark gray--}}
     <div class="thisMonth today-marker-today scroll-marker custom-md-85">
-@elseif ($weekDay->format('W') === date('W'))
+@elseif ($weekDay->format('W/o') === date('W/o'))
     {{-- Other day in this week --}}
     <div class="thisMonth today-marker custom-md-85">
 @elseif ($weekDay->format('m') === $month)


### PR DESCRIPTION
Info:
o: ISO-8601 week-numbering year. This has the same value as Y, except that if the ISO week number (W) belongs to the previous or next year, that year is used instead. (added in PHP 5.1.0)