### PR TITLE
change url ../ to route in Section Management View

### DIFF
--- a/resources/views/manageSections.blade.php
+++ b/resources/views/manageSections.blade.php
@@ -36,7 +36,8 @@
 									{!! $section->id !!}
 								</td>
 								<td>
-							      	<a href="./section/{{ $section->id }}">
+									
+							      	<a href="{{route("section.show",["id"=>$section->id])}}">
 							      		{!! $section->title !!}
 							      	</a>
 								</td>

--- a/resources/views/manageSections.blade.php
+++ b/resources/views/manageSections.blade.php
@@ -36,7 +36,7 @@
 									{!! $section->id !!}
 								</td>
 								<td>
-							      	<a href="../section/{{ $section->id }}">
+							      	<a href="./section/{{ $section->id }}">
 							      		{!! $section->title !!}
 							      	</a>
 								</td>


### PR DESCRIPTION
needs to be checked but I guess this comes from older structures and only works for domains where the domain name is linked the /public folder as domain.name/../test mostly resolves in domain.name/test

when subfolders are used this does not work, maybe there is a better way to reference the /public in general, but this was quick & dirty in the first place!