### PR TITLE
Add safer formatting to section titles

### DIFF
--- a/resources/assets/ts/Utilities.ts
+++ b/resources/assets/ts/Utilities.ts
@@ -5,6 +5,14 @@ function showErrorModal(message: string) {
     $("#errorModal").find(".modal-body").html(message);
 }
 
+export function convertToSafeFormat(str: string) {
+    // Replace spaces with a dash,
+    // remove special characters
+    // and then convert to lower case.
+    // Example: "Section Name 123 & 456" => "section-name-123-456"
+    return str.replace(/\W+/g, '-').toLowerCase();
+}
+
 export const safeSetLocalStorage = (key: string, prop: any) => {
     if (typeof(Storage) !== "undefined") {
         localStorage.setItem(key, prop);

--- a/resources/assets/ts/vedst-scripts.ts
+++ b/resources/assets/ts/vedst-scripts.ts
@@ -6,6 +6,7 @@ import * as bootbox from "bootbox"
 import {ToggleButton} from "./ToggleButton";
 import {makeLocalStorageAction, makeClassToggleAction} from "./ToggleAction";
 import {safeGetLocalStorage, safeSetLocalStorage} from "./Utilities";
+import {convertToSafeFormat} from "./Utilities";
 
 const jQuery = $;
 /////////////
@@ -43,7 +44,7 @@ $(function() {
         //Handle clicking on a section label
         $('.label-filters').click((e) => {
             //Deselect the clicked section
-            let section = (<HTMLSpanElement>e.target).id.slice(6);
+            let section = convertToSafeFormat((<HTMLSpanElement>e.target).id.slice(6));
             //Update the local storage
             safeSetLocalStorage("filter-" + section, "hide");
             //Uncheck the select option

--- a/resources/views/partials/filter.blade.php
+++ b/resources/views/partials/filter.blade.php
@@ -8,7 +8,8 @@
             <span class="glyphicon glyphicon-remove-circle"></span>
         </span>
         @foreach($sections->reverse() as $section)
-            <span id="label-{!! $section["title"] !!}" class="label label-filters palette-{{$section->color}}-500-Primary bg hidden pull-right">
+            {{-- Formatting: "Section Name 123" => "section-name-123" --}}
+            <span id="label-{!! str_replace(' ', '-', strtolower($section["title"])) !!}" class="label label-filters palette-{{$section->color}}-500-Primary bg hidden pull-right">
                 {!! $section["title"] !!}
                 &nbsp;
                 <span class="glyphicon glyphicon-remove-circle"></span>
@@ -26,7 +27,8 @@
                                              data-deselect-all-text="{{ trans('mainLang.selectNone') }}"
                                              data-count-selected-text="{{ trans('mainLang.countSectionsSelected') }}">
             @foreach($sections as $section)
-                <option value="filter-{!! $section["title"] !!}"
+                {{-- Formatting: "Section Name 123" => "section-name-123" --}}
+                <option value="filter-{!! str_replace(' ', '-', strtolower($section["title"])) !!}"
                         class="palette-{{$section->color}}-500-Primary bg option-shadow">
                             {!! $section["title"] !!}
                 </option>

--- a/resources/views/partials/month/monthCell.blade.php
+++ b/resources/views/partials/month/monthCell.blade.php
@@ -68,7 +68,8 @@
             <div class="{!! $clubEvent->section->title !!}">
         @else
             {{-- Normal scenario: add a css class according to filter data --}}
-            <div class="section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach">
+            {{-- Formatting: "Section Name 123" => "section-name-123" --}}
+            <div class="section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach">
         @endif
 
 

--- a/resources/views/weekView.blade.php
+++ b/resources/views/weekView.blade.php
@@ -78,16 +78,17 @@
 						@if($clubEvent->evnt_is_private)
 							{{-- we compare the current week number with the week the event happens in
 								 to catch and hide any events on mondays and tuesdays (day < 3) next week
-								 in Mo-So or alternatively mondays/tuesdays this week in Mi-Di view --}}
+								 in Mo-So or alternatively mondays/tuesdays this week in Mi-Di view.
+                                 Formatting: "Section Name 123" => "section-name-123" --}}
 							@if ( date('W', strtotime($clubEvent->evnt_date_start)) === $date['week']
 							  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mo-so">
+								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mo-so">
 							@elseif ( date("W", strtotime($clubEvent->evnt_date_start) )
 								  === date("W", strtotime("next Week".$weekStart))
 								  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mi-di hide">
+								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mi-di hide">
 							@else
-								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach">
+								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach">
 							@endif
 								@include('partials.weekCellHidden')
 							</div>
@@ -97,16 +98,17 @@
 
 							{{-- we compare the current week number with the week the event happens in
 								 to catch and hide any events on mondays and tuesdays (day < 3) next week
-								 in Mo-So or alternatively mondays/tuesdays this week in Mi-Di view --}}
+								 in Mo-So or alternatively mondays/tuesdays this week in Mi-Di view.
+                                 Formatting: "Section Name 123" => "section-name-123"  --}}
 							@if ( date('W', strtotime($clubEvent->evnt_date_start)) === $date['week']
 							  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mo-so">
+								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mo-so">
 							@elseif ( date("W", strtotime($clubEvent->evnt_date_start) )
 								  === date("W", strtotime("next Week".$weekStart))
 								  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mi-di hide">
+								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mi-di hide">
 							@else
-								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach">
+								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach">
 							@endif
 
 								@include('partials.weekCellProtected')
@@ -122,29 +124,30 @@
 
 							{{-- we compare the current week number with the week the event happens in
 								 to catch and hide any events on mondays and tuesdays (day < 3) next week
-								 in Mo-So or alternatively mondays/tuesdays this week in Mi-Di view --}}
+								 in Mo-So or alternatively mondays/tuesdays this week in Mi-Di view.
+                                 Formatting: "Section Name 123" => "section-name-123"  --}}
 							@if ( date('W', strtotime($clubEvent->evnt_date_start)) === $date['week']
 							  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mo-so">
+								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mo-so">
 							@elseif ( date("W", strtotime($clubEvent->evnt_date_start) )
 								  === date("W", strtotime("next Week".$weekStart))
 								  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mi-di hide">
+								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mi-di hide">
 							@else
-								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach">
+								<div class="element-item private section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach">
 							@endif
 
 						@else
 
 							@if ( date('W', strtotime($clubEvent->evnt_date_start)) === $date['week']
 							  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mo-so">
+								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mo-so">
 							@elseif ( date("W", strtotime($clubEvent->evnt_date_start) )
 								  === date("W", strtotime("next Week".$weekStart))
 								  && date('N', strtotime($clubEvent->evnt_date_start)) < 3 )
-								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach week-mi-di hide">
+								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach week-mi-di hide">
 							@else
-								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? $section->title : false !!} @endforeach">
+								<div class="element-item section-filter @foreach($sections as $section) {!! in_array( $section->title, $clubEvent->showToSectionNames() ) ? str_replace(' ', '-', strtolower($section->title)) : false !!} @endforeach">
 							@endif
 
 						@endif


### PR DESCRIPTION
Before: section titles containing spaces would break filters

After: convert section titles to a safe format before using as ID or filter, etc -> filters work with more complex titles too. 
Example: section "New Section 1" will get the ID "new-section-1" with dashes instead of spaces and all lower case.

![image](https://user-images.githubusercontent.com/11014468/45627948-5000f900-ba93-11e8-8e11-172933c022d6.png)
