### PR TITLE
Fix/authorization club events surveys

### DIFF
--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -317,6 +317,8 @@ class ClubEventController extends Controller
         /* @var $event ClubEvent */
         $event = ClubEvent::findOrFail($id);
 
+        $this->authorize('update', $event);
+
         // find schedule
         $schedule = $event->getSchedule;
 
@@ -418,6 +420,8 @@ class ClubEventController extends Controller
 
         // first we fill objects with data
         // if there is an error, we have not saved yet, so we need no rollback
+        //
+        $this->authorize('update', ClubEvent::find($id));
         $event = $this->editClubEvent($id);
 
         $schedule = (new ScheduleController)->update($event->getSchedule->id);

--- a/app/Http/Controllers/SurveyController.php
+++ b/app/Http/Controllers/SurveyController.php
@@ -43,10 +43,6 @@ class SurveyController extends Controller
         $this->middleware('rejectGuests', ['only' => 'create', 'store']);
         // if survey is private, reject guests
         $this->middleware('privateEntry:Lara\Survey,survey', ['except' => ['create', 'store']]);
-        // only Ersteller/Admin/Marketing/Clubleitung, privileged user groups only
-        $this->middleware('creator:Lara\Survey,survey', ['only' => ['edit', 'update', 'destroy']]);
-        // after deadline, only Ersteller/Admin/Marketing/Clubleitung, privileged user groups only
-        $this->middleware('deadlineSurvey', ['only' => ['edit', 'update', 'destroy']]);
     }
 
     /**
@@ -113,6 +109,8 @@ class SurveyController extends Controller
     {
         //find SurveyID
         $survey = Survey::findorFail($id);
+
+        $this->authorize('delete', $survey);
 
         foreach ($survey->answers as $answer) {
             foreach ($answer->cells as $cell) {
@@ -269,7 +267,7 @@ class SurveyController extends Controller
         unset($revision);
 
         //check if the role of the user allows edit/delete for all answers
-        $userCanEditDueToRole = $user==null?false:Auth::user()->isAn(RoleUtility::PRIVILEGE_CL);
+        $userCanEditDueToRole = $user==null? false :Auth::user()->can('update', $survey);
 
         //evaluation part that shows below the survey, a statistic of answers of the users who already took part in the survey
 
@@ -344,6 +342,8 @@ class SurveyController extends Controller
         //find survey
         $survey = Survey::findOrFail($id);
 
+        $this->authorize('update', $survey);
+
         //find questions and answer options
         $questions = $survey->questions;
         foreach ($questions as $question) {
@@ -367,6 +367,8 @@ class SurveyController extends Controller
     {
         //find survey
         $survey = Survey::findOrFail($id);
+
+        $this->authorize('update', $survey);
         $revision_survey = new Revision($survey);
 
         //edit existing survey

--- a/app/Policies/ClubEventPolicy.php
+++ b/app/Policies/ClubEventPolicy.php
@@ -4,6 +4,7 @@ namespace Lara\Policies;
 
 use Lara\User;
 use Lara\ClubEvent;
+use Lara\utilities\RoleUtility;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
 
@@ -20,7 +21,7 @@ class ClubEventPolicy
      */
     public function view(User $user, ClubEvent $clubEvent)
     {
-        //
+        return true;
     }
 
     /**
@@ -43,7 +44,22 @@ class ClubEventPolicy
      */
     public function update(User $user, ClubEvent $clubEvent)
     {
-        //
+        if ($user->isAn(RoleUtility::PRIVILEGE_ADMINISTRATOR)) {
+            return true;
+        }
+
+        if ($user->is($clubEvent->creator)) {
+            return true;
+        }
+
+        $isClOrMarketing = $user->isAn(RoleUtility::PRIVILEGE_CL, RoleUtility::PRIVILEGE_MARKETING);
+        $isSameSection = $user->section_id == $clubEvent->section->id;
+
+        if ($isClOrMarketing && $isSameSection) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/app/Policies/SurveyPolicy.php
+++ b/app/Policies/SurveyPolicy.php
@@ -4,6 +4,8 @@ namespace Lara\Policies;
 
 use Lara\User;
 use Lara\Survey;
+
+use Lara\utilities\RoleUtility;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class SurveyPolicy
@@ -42,7 +44,22 @@ class SurveyPolicy
      */
     public function update(User $user, Survey $survey)
     {
-        //
+        if ($user->isAn(RoleUtility::PRIVILEGE_ADMINISTRATOR)) {
+            return true;
+        }
+
+        if ($user->is($survey->creator->user)) {
+            return true;
+        }
+
+        $isClOrMarketing = $user->isAn(RoleUtility::PRIVILEGE_CL, RoleUtility::PRIVILEGE_MARKETING);
+        $isSameSection = $user->section_id == $survey->section()->id;
+
+        if ($isClOrMarketing && $isSameSection) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -54,6 +71,6 @@ class SurveyPolicy
      */
     public function delete(User $user, Survey $survey)
     {
-        //
+        return $this->update($user, $survey);
     }
 }

--- a/app/Policies/SurveyPolicy.php
+++ b/app/Policies/SurveyPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Lara\Policies;
+
+use Lara\User;
+use Lara\Survey;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class SurveyPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the survey.
+     *
+     * @param  \Lara\User  $user
+     * @param  \Lara\Survey  $survey
+     * @return mixed
+     */
+    public function view(User $user, Survey $survey)
+    {
+
+    }
+
+    /**
+     * Determine whether the user can create surveys.
+     *
+     * @param  \Lara\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the survey.
+     *
+     * @param  \Lara\User  $user
+     * @param  \Lara\Survey  $survey
+     * @return mixed
+     */
+    public function update(User $user, Survey $survey)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the survey.
+     *
+     * @param  \Lara\User  $user
+     * @param  \Lara\Survey  $survey
+     * @return mixed
+     */
+    public function delete(User $user, Survey $survey)
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,8 @@ namespace Lara\Providers;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
+use Lara\Policies\ClubEventPolicy;
+use Lara\Policies\SurveyPolicy;
 use Lara\Policies\RolePolicy;
 use Lara\Policies\UserPolicy;
 
@@ -29,7 +31,7 @@ class AuthServiceProvider extends ServiceProvider
         'Lara\Model' => 'Lara\Policies\ModelPolicy',
         User::class => UserPolicy::class,
         Role::class => RolePolicy::class,
-
+        ClubEvent::class => ClubEventPolicy::class
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -15,6 +15,7 @@ use Lara\Section;
 use Lara\User;
 use Lara\ClubEvent;
 use Lara\Schedule;
+use Lara\Survey;
 use Lara\utilities\RoleUtility;
 
 use Lara\Observers\ScheduleObserver;
@@ -31,7 +32,8 @@ class AuthServiceProvider extends ServiceProvider
         'Lara\Model' => 'Lara\Policies\ModelPolicy',
         User::class => UserPolicy::class,
         Role::class => RolePolicy::class,
-        ClubEvent::class => ClubEventPolicy::class
+        ClubEvent::class => ClubEventPolicy::class,
+        Survey::class => SurveyPolicy::class
     ];
 
     /**


### PR DESCRIPTION
Remove obsolete and obscure middleware from surveys and add a single place where permissions to edit / delete a survey or event are handled: the policies.