### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ package-lock.json
 .env
 .env-prod
 .env-local
+.env.testing
 
 # Composer specific files
 composer.phar

--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -534,7 +534,7 @@ class ClubEventController extends Controller
      * @param ClubEvent|null $event
      * @return ClubEvent clubEvent
      */
-    private function editClubEvent(ClubEvent $event)
+    private function editClubEvent(ClubEvent $event = null)
     {
         if (is_null($event)) {
             $event = new ClubEvent();

--- a/app/Policies/ClubEventPolicy.php
+++ b/app/Policies/ClubEventPolicy.php
@@ -7,67 +7,91 @@ use Lara\ClubEvent;
 use Lara\utilities\RoleUtility;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
 
 class ClubEventPolicy
 {
     use HandlesAuthorization;
 
     /**
+     * Perform pre-authorization checks. Admins can do anything
+     *
+     * @param  \App\Models\User  $user
+     * @param  string  $ability
+     * @return void|bool
+     */
+    public function before(User $user, $ability)
+    {
+        if ($user->isAn(RoleUtility::PRIVILEGE_ADMINISTRATOR)) {
+            return true;
+        }
+    }
+
+    /**
      * Determine whether the user can view the clubEvent.
      *
      * @param  \Lara\User  $user
-     * @param  \Lara\ClubEvent  $clubEvent
-     * @return mixed
+     * @param  \Lara\ClubEvent  $event
+     * @return bool
      */
-    public function view(User $user, ClubEvent $clubEvent)
+    public function view(?User $user, ClubEvent $event)
     {
+        if (!$user && $event->evnt_is_private == 1) {
+            return false;
+        }
         return true;
     }
 
     /**
      * Determine whether the user can create clubEvents.
+     * Any logged in user can create an event
      *
      * @param  \Lara\User  $user
-     * @return mixed
+     * @return bool
      */
     public function create(User $user)
     {
-        //
+        return true;
     }
 
     /**
      * Determine whether the user can update the clubEvent.
+     * The creator, CL & marketing belonging to that section can update the event.
      *
      * @param  \Lara\User  $user
-     * @param  \Lara\ClubEvent  $clubEvent
-     * @return mixed
+     * @param  \Lara\ClubEvent  $event
+     * @return \Illuminate\Auth\Access\Response
      */
-    public function update(User $user, ClubEvent $clubEvent)
+    public function update(User $user, ClubEvent $event)
     {
-        if ($user->isAn(RoleUtility::PRIVILEGE_ADMINISTRATOR)) {
-            return true;
+        if ($user->is($event->creator)) {
+            return Response::allow();
         }
 
-        if ($user->is($clubEvent->creator)) {
-            return true;
+        if ($user->hasPermissionsInSection($event->section, RoleUtility::PRIVILEGE_CL, RoleUtility::PRIVILEGE_MARKETING)) {
+            return Response::allow();
         }
 
-        if ($user->hasPermissionsInSection($clubEvent->section, RoleUtility::PRIVILEGE_CL, RoleUtility::PRIVILEGE_MARKETING)) {
-            return true;
-        }
-
-        return false;
+        return Response::deny(__('mainlang.cantUpdateEvent'));
     }
 
     /**
      * Determine whether the user can delete the clubEvent.
-     *
+     * The creator as long as the event is private, CL & marketing belonging to that section can delete the event.
      * @param  \Lara\User  $user
-     * @param  \Lara\ClubEvent  $clubEvent
-     * @return mixed
+     * @param  \Lara\ClubEvent  $event
+     * @return \Illuminate\Auth\Access\Response
      */
-    public function delete(User $user, ClubEvent $clubEvent)
+    public function delete(User $user, ClubEvent $event)
     {
-        //
+        if ($user->is($event->creator) && $event->evnt_is_private) {
+            return Response::allow();
+        }
+
+        if ($user->hasPermissionsInSection($event->section, RoleUtility::PRIVILEGE_CL, RoleUtility::PRIVILEGE_MARKETING)) {
+            return Response::allow();
+        }
+
+        return Response::deny(__('mainLang.cantDeleteEvent'));
     }
 }

--- a/resources/assets/sass/views/monthView.scss
+++ b/resources/assets/sass/views/monthView.scss
@@ -139,6 +139,16 @@ span.event-time{
     font-size:x-small;
 }
 
+.day-cell a{
+    font-weight: 500;
+    color: inherit;
+    text-decoration: inherit;
+}
+
+.day-cell a:hover{
+    text-decoration: underline;
+}
+
 .day-cell-events{
     padding-right: 6px;
     padding-left:2px;
@@ -147,21 +157,6 @@ span.event-time{
 .day-cell-events{
     word-break: initial;
     word-wrap: break-word;
-}
-
-.day-cell a:link,
-.calendarWeek a:link {
-    color: #666666;
-}
-
-.day-cell a:hover,
-.calendarWeek a:hover {
-    color: #040303;
-}
-
-.day-cell a:visited,
-.calendarWeek a:visited {
-    color: #666666;
 }
 
 

--- a/resources/assets/sass/views/weekView.scss
+++ b/resources/assets/sass/views/weekView.scss
@@ -23,6 +23,10 @@
   text-decoration: none;
 }
 
+.card-columns .card{
+  break-inside: avoid-column;
+}
+
 .card {
   margin-bottom: 0px !important;
 }

--- a/resources/lang/de/mainLang.php
+++ b/resources/lang/de/mainLang.php
@@ -77,6 +77,7 @@ return [
 
     'additionalInfo'        => 'Weitere Details',
     'moreDetails'           => 'Interne Information',
+    'noShifts'              => 'Diese Veranstaltung hat keine Dienste.',
 
     //Button
     'showMore'              => 'mehr anzeigen',

--- a/resources/lang/de/mainLang.php
+++ b/resources/lang/de/mainLang.php
@@ -430,6 +430,8 @@ return [
     */
 
     //ClubEvent
+    'cantDeleteEvent'               => 'Nur Administratoren, CLs und Marketing-Mitglieder, die der Sektion der Veranstaltung angehören, können die Veranstaltung löschen.',
+    'cantUpdateEvent'               => 'Nur Administratoren, CLs und Marketing-Mitglieder, die der Sektion der Veranstaltung angehören, und der Ersteller der Veranstaltung können die Veranstaltung ändern.',
     'addCommentHere'                => 'Kommentar hier hinzufügen',
     'enterPasswordHere'             => 'Passwort hier eingeben',
     'placeholderTitleWineEvening'   => 'z.B. Weinabend',
@@ -455,7 +457,7 @@ return [
     'dark'                          => 'Dunkel',
     //ShiftName
     '=FREI='                        => '=FREI=', //not used yet
-
+ 
     //ShiftTitle
     'optional'                      => 'Optional',
     'optionalShort'                 => 'Opt.',

--- a/resources/lang/en/mainLang.php
+++ b/resources/lang/en/mainLang.php
@@ -430,6 +430,8 @@ return [
     */
 
     //ClubEvent
+    'cantDeleteEvent'               => 'Only administrators, CLs and Marketing members belonging to the event\'s section can delete an event.',
+    'cantUpdateEvent'               => 'Only administrators, CLs and Marketing members belonging to the event\'s section, and the creator of the event can delete an event.',
     'addCommentHere'                => 'Add comment here',
     'enterPasswordHere'             => 'Enter password here',
     'placeholderTitleWineEvening'   => 'e.g. Wine evening', //'placeholderTitleWineEvening'

--- a/resources/lang/en/mainLang.php
+++ b/resources/lang/en/mainLang.php
@@ -76,6 +76,7 @@ return [
 
     'additionalInfo'        => 'Additional details',
     'moreDetails'           => 'Internal information',
+    'noShifts'              => 'This event has no shifts.',
 
     //Button
     'showMore'              => 'show more',

--- a/resources/lang/pirate/mainLang.php
+++ b/resources/lang/pirate/mainLang.php
@@ -77,6 +77,7 @@ return [
 
     'additionalInfo'        => 'Flaschenpost',
     'moreDetails'           => 'Ansagen vom Kapitän',
+    'noShifts'              => 'Diese Veranstaltung hat keine Sklaven.',
 
     //Button
     'showMore'              => 'Mehr!',

--- a/resources/lang/pirate/mainLang.php
+++ b/resources/lang/pirate/mainLang.php
@@ -430,6 +430,8 @@ return [
     */
 
     //ClubEvent
+    'cantDeleteEvent'               => 'Nur Administratoren, CLs und Marketing-Mitglieder, die der Sektion der Veranstaltung angehören, können die Veranstaltung löschen.',
+    'cantUpdateEvent'               => 'Nur Administratoren, CLs und Marketing-Mitglieder, die der Sektion der Veranstaltung angehören, und der Ersteller der Veranstaltung können die Veranstaltung ändern.',
     'addCommentHere'                => 'Blödsinn ausrufen',
     'enterPasswordHere'             => 'Passwort hier eingeben',
     'placeholderTitleWineEvening'   => 'z.B. Weinabend',

--- a/resources/views/clubevent/clubEventView.blade.php
+++ b/resources/views/clubevent/clubEventView.blade.php
@@ -204,6 +204,7 @@
             </div>
         </div>
 
+        @if(!$shifts->isEmpty())
         <div class="row my-3 hidden-print justify-content-start">
             <div class="col-md-5">
                 <div class="btn-group" role="group" aria-label="Filters">
@@ -224,8 +225,14 @@
                 </div>
             </div>
         </div>
+        @endif
 
         <div class="row mb-3 justify-content-center">
+            @if($shifts->isEmpty())
+            <div class="alert alert-info col-md-9 mt-4" role="alert">
+                {{__('mainLang.noShifts')}}
+              </div>
+            @else
             <div class="col-12 mx-sm-1 m-auto">
                 <div class="card">
                     @if ($clubEvent->getSchedule->schdl_password != '')
@@ -255,6 +262,7 @@
                     @endif
                 </div>
             </div>
+            @endif
         </div>
     </div>
 

--- a/resources/views/clubevent/clubEventView.blade.php
+++ b/resources/views/clubevent/clubEventView.blade.php
@@ -164,11 +164,7 @@
                     </div>
 
                     {{-- CRUD --}}
-                    @isInSection(['marketing', 'clubleitung', 'admin'], $clubEvent->section)
-                        @include('partials/events/editOptions', ['event' => $clubEvent])
-                    @elseif(Lara\Person::isCurrent($created_by))
-                        @include('partials/events/editOptions', ['event' => $clubEvent])
-                    @endisInSection
+                    @include('partials/events/editOptions', ['event' => $clubEvent])
                 </div>
             </div>
 

--- a/resources/views/partials/events/editOptions.blade.php
+++ b/resources/views/partials/events/editOptions.blade.php
@@ -30,7 +30,7 @@
         @endis
 
         --}}
-
+        @can('update', $clubEvent)
         <a href="{{ URL::route('event.edit', $event->id) }}"
            class="btn btn-primary"
            data-bs-toggle="tooltip"
@@ -38,9 +38,10 @@
            title="{{ __('mainLang.changeEvent') }}">
            <i class="fa-solid  fa-pencil-alt"></i>
         </a>
-        &nbsp;&nbsp;
+        @endcan
+        @can('delete', $clubEvent)
         <a href="{{ $event->id }}"
-           class="btn btn-danger"
+           class="btn btn-danger ms-2"
            data-bs-toggle="tooltip"
            data-bs-placement="top"
            title="{{ __('mainLang.deleteEvent') }}"
@@ -50,5 +51,6 @@
            data-confirm="{{ __('mainLang.confirmDeleteEvent') }}">
            <i class="fa-solid  fa-trash"></i>
         </a>
+        @endcan
     </span>
 </div>

--- a/resources/views/partials/shifts/takeShiftBar.blade.php
+++ b/resources/views/partials/shifts/takeShiftBar.blade.php
@@ -67,7 +67,7 @@ if($hideComments){
         <div style="width:10%; min-width:70px;">
             <div id="{!! 'club' . $shift->id !!}" class="form-group form-group-sm ">
                 <div class="form-control form-control-sm">
-                    {!! "(" . $shift->getPerson->getClub->clb_title . ")" !!}
+                    {!!  $shift->getPerson->getClub ? "(" . $shift->getPerson->getClub->clb_title . ")" : "" !!}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Day number made more readable on the month view.
- Enforced permission policies for all ClubEvent CRUD methods. The UI uses now the same logic using the blade @can
- Show a message when there are no shifts on the Event page (instead of the empty card). Avoid showing the not working filter buttons when that is the case.
- In the week view, the event cards do not break within columns